### PR TITLE
don't trigger Null traverser on xml literal

### DIFF
--- a/src/main/scala/wartremover/warts/Null.scala
+++ b/src/main/scala/wartremover/warts/Null.scala
@@ -6,10 +6,13 @@ object Null extends WartTraverser {
     import u.universe._
 
     val UnapplyName: TermName = "unapply"
+    val elemSymbol = rootMirror.staticClass("scala.xml.Elem")
     new Traverser {
       override def traverse(tree: Tree) {
         val synthetic = isSynthetic(u)(tree)
         tree match {
+          // Ignore xml literals
+          case Apply(Select(left, _), _) if left.tpe.baseType(elemSymbol) != NoType =>
           // Ignore synthetic case class's companion object unapply
           case ModuleDef(mods, _, Template(parents, self, stats)) if synthetic =>
             mods.annotations foreach { annotation =>

--- a/src/test/scala/wartremover/warts/NullTest.scala
+++ b/src/test/scala/wartremover/warts/NullTest.scala
@@ -35,4 +35,11 @@ class NullTest extends FunSuite {
     assert(result.errors == List.empty)
     assert(result.warnings == List.empty)
   }
+  test("can use xml literals") {
+    val result = WartTestTraverser(Null) {
+      val x = <foo />
+    }
+    assert(result.errors == List.empty)
+    assert(result.warnings == List.empty)
+  }
 }


### PR DESCRIPTION
Fixes #24, though in kind of a mediocre way -- this would also ignore a user's direct usage of `new scala.xml.Elem(null, ...`
