### PR TITLE
wart for return statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,16 @@ projection.  The program should be refactored to use `scala.util.Either.LeftProj
 and `scala.util.Either.RightProjection#toOption` to explicitly handle both
 the `Some` and `None` cases.
 
+### Return
+
+`return` breaks referential transparency. Refactor to terminate computations in a safe way.
+
+```scala
+// Won't compile: return is disabled
+def foo(n:Int): Int = return n + 1
+def foo(ns: List[Int]): Any = ns.map(n => return n + 1)
+```
+
 ### Unsafe
 
 Checks for the following warts:
@@ -122,6 +132,7 @@ Checks for the following warts:
 * OptionPartial
 * EitherProjectionPartial
 * Var
+* Return
 
 ### Var
 

--- a/src/main/scala/wartremover/warts/Return.scala
+++ b/src/main/scala/wartremover/warts/Return.scala
@@ -1,0 +1,18 @@
+package org.brianmckenna.wartremover
+package warts
+
+object Return extends WartTraverser {
+  def apply(u: WartUniverse): u.Traverser = {
+    import u.universe._
+    new Traverser {
+      override def traverse(tree: Tree) {
+        tree match {
+          case u.universe.Return(_) =>
+            u.error(tree.pos, "return is disabled")
+          case _ =>
+        }
+        super.traverse(tree)
+      }
+    }
+  }
+}

--- a/src/main/scala/wartremover/warts/Unsafe.scala
+++ b/src/main/scala/wartremover/warts/Unsafe.scala
@@ -8,7 +8,8 @@ object Unsafe extends WartTraverser {
     Null,
     OptionPartial,
     EitherProjectionPartial,
-    Var
+    Var,
+    Return
   )
 
   def apply(u: WartUniverse): u.Traverser =

--- a/src/test/scala/wartremover/warts/Return.scala
+++ b/src/test/scala/wartremover/warts/Return.scala
@@ -1,0 +1,23 @@
+package org.brianmckenna.wartremover
+package test
+
+import org.scalatest.FunSuite
+
+import org.brianmckenna.wartremover.warts.Return
+
+class ReturnTest extends FunSuite {
+  test("local return is disabled") {
+    val result = WartTestTraverser(Return) {
+      def foo(n:Int): Int = return n + 1
+    }
+    assert(result.errors == List("return is disabled"))
+    assert(result.warnings == List.empty)
+  }
+  test("nonlocal return is disabled") {
+    val result = WartTestTraverser(Return) {
+      def foo(ns: List[Int]): Any = ns.map(n => return n + 1)
+    }
+    assert(result.errors == List("return is disabled"))
+    assert(result.warnings == List.empty)
+  }
+}


### PR DESCRIPTION
Wart for `return` statement, if this interests you. Added to `Unsafe` which may or may not be desirable.
