### PR TITLE
Suggest symbolic matching, rather than name based matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,12 +162,15 @@ import org.brianmckenna.wartremover.{WartTraverser, WartUniverse}
 object Unimplemented extends WartTraverser {
   def apply(u: WartUniverse): u.Traverser = {
     import u.universe._
+    import scala.reflect.NameTransformer
 
-    val NotImplementedName: TermName = "$qmark$qmark$qmark" // ???
+    val notImplementedName: TermName = NameTransformer.encode("???")
+    val notImplemented: Symbol = typeOf[Predef.type].member(notImplementedName)
+    require(notImplemented != NoSymbol)
     new Traverser {
       override def traverse(tree: Tree) {
         tree match {
-          case Select(_, NotImplementedName) =>
+          case rt: RefTree if rt.symbol == notImplemented =>
             u.error(tree.pos, "There was something left unimplemented")
           case _ =>
         }


### PR DESCRIPTION
This is more robust. It avoids false positives for unrelated
methods with the same name, and false negatives when the selection
is made via an aliased import.

I've tested that this version compiles and works.
