### PR TITLE
Ignore non-Unit statements in desugaring of XML literals

### DIFF
--- a/src/main/scala/wartremover/warts/NonUnitStatements.scala
+++ b/src/main/scala/wartremover/warts/NonUnitStatements.scala
@@ -4,13 +4,19 @@ package warts
 object NonUnitStatements extends WartTraverser {
   def apply(u: WartUniverse): u.Traverser = {
     import u.universe._
+    import scala.reflect.NameTransformer
 
     val PrintName: TermName = "$print"
+    val NodeBufferAddName: TermName = NameTransformer.encode("&+")
 
     def isIgnoredStatement(tree: Tree) = tree match {
       // Scala creates synthetic blocks with <init> calls on classes.
       // The calls return Object so we need to ignore them.
       case Apply(Select(_, nme.CONSTRUCTOR), _) => true
+      // scala.xml.NodeBuffer#&+ returns NodeBuffer instead of Unit, so
+      // val x = <x>5</x> desugars to a non-Unit statement; ignore.
+      case Apply(Select(qual, NodeBufferAddName), _)
+        if qual.symbol.typeSignature =:= typeOf[scala.xml.NodeBuffer] => true
       case _ => false
     }
 

--- a/src/test/scala/wartremover/warts/NonUnitStatementsTest.scala
+++ b/src/test/scala/wartremover/warts/NonUnitStatementsTest.scala
@@ -14,4 +14,12 @@ class NonUnitStatementsTest extends FunSuite {
     assert(result.errors == List("Statements must return Unit"))
     assert(result.warnings == List.empty)
   }
+  test("XML literals don't fail") {
+    val result = WartTestTraverser(NonUnitStatements) {
+      val a = 13
+      <x>{a}</x>
+    }
+    assert(result.errors == List.empty)
+    assert(result.warnings == List.empty)
+  }
 }


### PR DESCRIPTION
Solves issue #32.
