### PR TITLE
Allow `xmlns' attribute in XML literals

### DIFF
--- a/src/main/scala/wartremover/warts/Null.scala
+++ b/src/main/scala/wartremover/warts/Null.scala
@@ -6,13 +6,15 @@ object Null extends WartTraverser {
     import u.universe._
 
     val UnapplyName: TermName = "unapply"
-    val elemSymbol = rootMirror.staticClass("scala.xml.Elem")
+    val xmlSymbols = (classOf[scala.xml.Elem]
+      :: classOf[scala.xml.NamespaceBinding]
+      :: Nil) map (c => rootMirror.staticClass(c.getCanonicalName))
     new Traverser {
       override def traverse(tree: Tree) {
         val synthetic = isSynthetic(u)(tree)
         tree match {
           // Ignore xml literals
-          case Apply(Select(left, _), _) if left.tpe.baseType(elemSymbol) != NoType =>
+          case Apply(Select(left, _), _) if xmlSymbols exists (left.tpe.baseType(_) != NoType) =>
           // Ignore synthetic case class's companion object unapply
           case ModuleDef(mods, _, Template(parents, self, stats)) =>
             mods.annotations foreach { annotation =>

--- a/src/test/scala/wartremover/warts/NullTest.scala
+++ b/src/test/scala/wartremover/warts/NullTest.scala
@@ -42,4 +42,11 @@ class NullTest extends FunSuite {
     assert(result.errors == List.empty)
     assert(result.warnings == List.empty)
   }
+  test("can use xmlns attrib in XML literals") {
+    val result = WartTestTraverser(Null) {
+      <x xmlns="y"/>
+    }
+    assert(result.errors == List.empty)
+    assert(result.warnings == List.empty)
+  }
 }


### PR DESCRIPTION
`<x xmlns=""/>` is desugared to:

```
private[this] val res0: scala.xml.Elem = {
  var $tmpscope: scala.xml.NamespaceBinding = scala.this.Predef.$scope;
  $tmpscope = new scala.xml.NamespaceBinding(null, null, $tmpscope);
  {
    val $scope: scala.xml.NamespaceBinding = $tmpscope;
    new scala.xml.Elem(null, "x", scala.xml.Null, $scope, true)
  }
};
```

So not only we need to ignore `null` parameters of `scala.xml.Elem` constructor, but also of `scala.xml.NamespaceBinding`.
