### PR TITLE
improved test error reporting

### DIFF
--- a/src/test/scala/wartremover/safe/CaseClassTest.scala
+++ b/src/test/scala/wartremover/safe/CaseClassTest.scala
@@ -11,7 +11,7 @@ class CaseClassTest extends FunSuite {
       case class A(a: Int)
       case class B[X](a: X)
     }
-    assert(result.errors == List.empty)
-    assert(result.warnings == List.empty)
+    expectResult(List.empty, "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/src/test/scala/wartremover/safe/CompanionTest.scala
+++ b/src/test/scala/wartremover/safe/CompanionTest.scala
@@ -12,7 +12,7 @@ class CompanionTest extends FunSuite {
       object Foo {
       }
     }
-    assert(result.errors == List.empty)
-    assert(result.warnings == List.empty)
+    expectResult(List.empty, "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/src/test/scala/wartremover/safe/PartialFunctionTest.scala
+++ b/src/test/scala/wartremover/safe/PartialFunctionTest.scala
@@ -17,7 +17,7 @@ class PartialFunctionTest extends FunSuite {
         case 3 => 4
       }
     }
-    assert(result.errors == List.empty)
-    assert(result.warnings == List.empty)
+    expectResult(List.empty, "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/src/test/scala/wartremover/safe/XmlLiteralTest.scala
+++ b/src/test/scala/wartremover/safe/XmlLiteralTest.scala
@@ -10,21 +10,21 @@ class XmlLiteralTest extends FunSuite {
     val result = WartTestTraverser(Unsafe) {
       val x = <foo />
     }
-    assert(result.errors == List.empty)
-    assert(result.warnings == List.empty)
+    expectResult(List.empty, "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
   }
   test("can use attributes in xml literals") {
     val result = WartTestTraverser(Unsafe) {
       <foo bar="baz" />
     }
-    assert(result.errors == List.empty)
-    assert(result.warnings == List.empty)
+    expectResult(List.empty, "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
   }
   test("can use xmlns attrib in XML literals") {
     val result = WartTestTraverser(Unsafe) {
       <x xmlns="y"/> // this one has special meaning
     }
-    assert(result.errors == List.empty)
-    assert(result.warnings == List.empty)
+    expectResult(List.empty, "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/src/test/scala/wartremover/warts/Any2StringAddTest.scala
+++ b/src/test/scala/wartremover/warts/Any2StringAddTest.scala
@@ -10,7 +10,7 @@ class Any2StringAddTest extends FunSuite {
     val result = WartTestTraverser(Any2StringAdd) {
       {} + "lol"
     }
-    assert(result.errors == List("Scala inserted an any2stringadd call"))
-    assert(result.warnings == List.empty)
+    expectResult(List("Scala inserted an any2stringadd call"), "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/src/test/scala/wartremover/warts/AnyTest.scala
+++ b/src/test/scala/wartremover/warts/AnyTest.scala
@@ -11,7 +11,7 @@ class AnyTest extends FunSuite {
       val x = readf1("{0}")
       x
     }
-    assert(result.errors == List("Inferred type containing Any"))
-    assert(result.warnings == List.empty)
+    expectResult(List("Inferred type containing Any"), "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/src/test/scala/wartremover/warts/EitherProjectionPartialTest.scala
+++ b/src/test/scala/wartremover/warts/EitherProjectionPartialTest.scala
@@ -10,28 +10,28 @@ class EitherProjectionPartialTest extends FunSuite {
     val result = WartTestTraverser(EitherProjectionPartial) {
       println(Left(1).left.get)
     }
-    assert(result.errors == List("LeftProjection#get is disabled - use LeftProjection#toOption instead"))
-    assert(result.warnings == List.empty)
+    expectResult(List("LeftProjection#get is disabled - use LeftProjection#toOption instead"), "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
   }
   test("can't use LeftProjection#get on Right") {
     val result = WartTestTraverser(EitherProjectionPartial) {
       println(Right(1).left.get)
     }
-    assert(result.errors == List("LeftProjection#get is disabled - use LeftProjection#toOption instead"))
-    assert(result.warnings == List.empty)
+    expectResult(List("LeftProjection#get is disabled - use LeftProjection#toOption instead"), "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
   }
   test("can't use RightProjection#get on Left") {
     val result = WartTestTraverser(EitherProjectionPartial) {
       println(Left(1).right.get)
     }
-    assert(result.errors == List("RightProjection#get is disabled - use RightProjection#toOption instead"))
-    assert(result.warnings == List.empty)
+    expectResult(List("RightProjection#get is disabled - use RightProjection#toOption instead"), "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
   }
   test("can't use RightProjection#get on Right") {
     val result = WartTestTraverser(EitherProjectionPartial) {
       println(Right(1).right.get)
     }
-    assert(result.errors == List("RightProjection#get is disabled - use RightProjection#toOption instead"))
-    assert(result.warnings == List.empty)
+    expectResult(List("RightProjection#get is disabled - use RightProjection#toOption instead"), "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/src/test/scala/wartremover/warts/NonUnitStatementsTest.scala
+++ b/src/test/scala/wartremover/warts/NonUnitStatementsTest.scala
@@ -11,15 +11,15 @@ class NonUnitStatementsTest extends FunSuite {
       1
       2
     }
-    assert(result.errors == List("Statements must return Unit"))
-    assert(result.warnings == List.empty)
+    expectResult(List("Statements must return Unit"), "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
   }
   test("XML literals don't fail") {
     val result = WartTestTraverser(NonUnitStatements) {
       val a = 13
       <x>{a}</x>
     }
-    assert(result.errors == List.empty)
-    assert(result.warnings == List.empty)
+    expectResult(List.empty, "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/src/test/scala/wartremover/warts/NothingTest.scala
+++ b/src/test/scala/wartremover/warts/NothingTest.scala
@@ -11,7 +11,7 @@ class NothingTest extends FunSuite {
       val x = ???
       x
     }
-    assert(result.errors == List("Inferred type containing Nothing"))
-    assert(result.warnings == List.empty)
+    expectResult(List("Inferred type containing Nothing"), "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/src/test/scala/wartremover/warts/NullTest.scala
+++ b/src/test/scala/wartremover/warts/NullTest.scala
@@ -10,22 +10,22 @@ class NullTest extends FunSuite {
     val result = WartTestTraverser(Null) {
       println(null)
     }
-    assert(result.errors == List("null is disabled"))
-    assert(result.warnings == List.empty)
+    expectResult(List("null is disabled"), "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
   }
   test("can't use null in patterns") {
     val result = WartTestTraverser(Null) {
       val (a, b) = (1, null)
       println(a)
     }
-    assert(result.errors == List("null is disabled"))
-    assert(result.warnings == List.empty)
+    expectResult(List("null is disabled"), "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
   }
   test("can't use null inside of Map#partition") {
     val result = WartTestTraverser(Null) {
       Map(1 -> "one", 2 -> "two").partition { case (k, v) => null.asInstanceOf[Boolean] }
     }
-    assert(result.errors == List("null is disabled"))
-    assert(result.warnings == List.empty)
+    expectResult(List("null is disabled"), "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/src/test/scala/wartremover/warts/OptionPartialTest.scala
+++ b/src/test/scala/wartremover/warts/OptionPartialTest.scala
@@ -10,22 +10,22 @@ class OptionPartialTest extends FunSuite {
     val result = WartTestTraverser(OptionPartial) {
       println(Some(1).get)
     }
-    assert(result.errors == List("Option#get is disabled - use Option#fold instead"))
-    assert(result.warnings == List.empty)
+    expectResult(List("Option#get is disabled - use Option#fold instead"), "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
   }
   test("can't use Option#get on None") {
     val result = WartTestTraverser(OptionPartial) {
       println(None.get)
     }
-    assert(result.errors == List("Option#get is disabled - use Option#fold instead"))
-    assert(result.warnings == List.empty)
+    expectResult(List("Option#get is disabled - use Option#fold instead"), "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
   }
   test("doesn't detect other `get` methods") {
     val result = WartTestTraverser(OptionPartial) {
       case class A(get: Int)
       println(A(1).get)
     }
-    assert(result.errors == List.empty)
-    assert(result.warnings == List.empty)
+    expectResult(List.empty, "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/src/test/scala/wartremover/warts/ProductTest.scala
+++ b/src/test/scala/wartremover/warts/ProductTest.scala
@@ -10,7 +10,7 @@ class ProductTest extends FunSuite {
     val result = WartTestTraverser(Product) {
       List((1, 2, 3), (1, 2))
     }
-    assert(result.errors == List("Inferred type containing Product"))
-    assert(result.warnings == List.empty)
+    expectResult(List("Inferred type containing Product"), "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/src/test/scala/wartremover/warts/Return.scala
+++ b/src/test/scala/wartremover/warts/Return.scala
@@ -10,14 +10,14 @@ class ReturnTest extends FunSuite {
     val result = WartTestTraverser(Return) {
       def foo(n:Int): Int = return n + 1
     }
-    assert(result.errors == List("return is disabled"))
-    assert(result.warnings == List.empty)
+    expectResult(List("return is disabled"), "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
   }
   test("nonlocal return is disabled") {
     val result = WartTestTraverser(Return) {
       def foo(ns: List[Int]): Any = ns.map(n => return n + 1)
     }
-    assert(result.errors == List("return is disabled"))
-    assert(result.warnings == List.empty)
+    expectResult(List("return is disabled"), "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/src/test/scala/wartremover/warts/SerializableTest.scala
+++ b/src/test/scala/wartremover/warts/SerializableTest.scala
@@ -10,7 +10,7 @@ class SerializableTest extends FunSuite {
     val result = WartTestTraverser(Serializable) {
       List((1, 2, 3), (1, 2))
     }
-    assert(result.errors == List("Inferred type containing Serializable"))
-    assert(result.warnings == List.empty)
+    expectResult(List("Inferred type containing Serializable"), "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/src/test/scala/wartremover/warts/UnsafeTest.scala
+++ b/src/test/scala/wartremover/warts/UnsafeTest.scala
@@ -17,7 +17,7 @@ class UnsafeTest extends FunSuite {
       println(Right(42).right.get)
       println(null)
     }
-    assert(result.errors ==
+    expectResult(
       List("Inferred type containing Any",
            "Inferred type containing Any",
            "Scala inserted an any2stringadd call",
@@ -28,7 +28,7 @@ class UnsafeTest extends FunSuite {
            "Statements must return Unit",
            "null is disabled",
            "Option#get is disabled - use Option#fold instead",
-           "var is disabled"))
-    assert(result.warnings == List.empty)
+           "var is disabled"), "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/src/test/scala/wartremover/warts/VarTest.scala
+++ b/src/test/scala/wartremover/warts/VarTest.scala
@@ -11,7 +11,7 @@ class VarTest extends FunSuite {
       var x = 10
       x
     }
-    assert(result.errors == List("var is disabled"))
-    assert(result.warnings == List.empty)
+    expectResult(List("var is disabled"), "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
   }
 }


### PR DESCRIPTION
Wanted to make it clearer what the failures were from the new @michalrus tests, so I changed `assert` to `expectResult` everywhere. Failures now explain what happened:

```
[info] - can use attributes in xml literals *** FAILED ***
[info]   result.errors
[info] Expected List(), but got List(var is disabled) (XmlLiteralTest.scala:20)
```

Any objections?
