### PR TITLE
add scope for scalacOptions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Compile the command-line tool via `sbt assembly`.
 
 ### Compiler plugin
 
-Add the following to `build.sbt`.
+Add the following to `build.sbt`:
 
 ```scala
 resolvers += Resolver.sonatypeRepo("releases")


### PR DESCRIPTION
WartRemover doesn't really work in the REPL, so we should suggest a scope in the readme.
