### PR TITLE
update `ForbidInstance` to exclude object superclass and synthetic classes

### DIFF
--- a/src/main/scala/wartremover/warts/ForbidInference.scala
+++ b/src/main/scala/wartremover/warts/ForbidInference.scala
@@ -21,9 +21,13 @@ trait ForbidInference[T] extends WartTraverser {
           case tpt @ TypeTree() if wasInferred(u)(tpt) && tpt.tpe.contains(tSymbol) =>
             error()
 
-          // Ignore case classes generated methods
-          case ModuleDef(_, _, Template((_, _, statements))) if synthetic =>
+          // Ignore inferred supertypes for all `object` declarations
+          case ModuleDef(_, _, Template((_, _, statements))) =>
             statements.foreach(super.traverse)
+
+          // Ignore inference for all synthetic classes
+          case ClassDef(_, _, _, _) if synthetic =>
+
           case DefDef(_, CanEqualName | EqualsName | ProductElementName | ProductIteratorName, _, _, _, _) if synthetic =>
 
           case _ =>


### PR DESCRIPTION
This fixes #37 and #40 but please review my reasoning before merging.
- `Serializable` is added as a superclass for all companion objects (even explicit ones), and it's not obvious how to detect the non-synthetic case. So I turned off the `ForbidInstance` check for object superclasses in general. Object declarations are not expressions so I think this is ok.
- `Serializable` is also added as a superclass for synthetic implementations of `PartialFunction`. As these declarations (again) are not expressions and there's nothing to be done about it anyway, I turned off the `ForbidInstance` check for synthetic classes altogether.

This makes me wonder if we should disable all warts generically for all synthetic declarations. Are there any cases where a wart in synthetic code can meaningfully be reported to the user?

Also there remains [at least] a case where the compiler wants to infer `Product with Serializable with Foo` for an RHS type parameter when `Foo` is given on the LHS. It happens in some of my argonaut code but I haven't been able to make a minimal example yet. So even if the changes above are acceptable we're still not quite out of the woods.
