### PR TITLE
candidate unsafe == wart

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,16 @@ projection.  The program should be refactored to use `scala.util.Either.LeftProj
 and `scala.util.Either.RightProjection#toOption` to explicitly handle both
 the `Some` and `None` cases.
 
+
+### Equal
+
+Universal equality breaks parametricity and should be avoided, but if you insist on using it you probably don't want to compare types that don't conform with each other. This wart disables comparison between types if the don't conform in either direction.
+
+```scala
+// Won't compile: Non-conforming types List[Int] and scala.collection.immutable.Set[Int] cannot be compared
+List(1) == Set(1)
+```
+
 ### IsInstanceOf
 
 `isInstanceOf` violates parametricity. Refactor so that the  type is established statically.

--- a/src/main/scala/wartremover/warts/Equal.scala
+++ b/src/main/scala/wartremover/warts/Equal.scala
@@ -9,16 +9,17 @@ object Equal extends WartTraverser {
     import u.universe._
 
     val EqEqName: TermName = NameTransformer.encode("==")
+    val Equals: TermName = NameTransformer.encode("equals")
 
     // We can only compare types that conform
-    def bogus(a: Type, b: Type): Boolean = 
+    def nonConforming(a: Type, b: Type): Boolean = 
       !(a <:< b || b <:< a)
 
     new Traverser {
       override def traverse(tree: Tree) {
         tree match {
 
-          case Apply(Select(lhs, EqEqName), List(rhs)) if bogus(lhs.tpe, rhs.tpe) =>
+          case Apply(Select(lhs, EqEqName | Equals), List(rhs)) if nonConforming(lhs.tpe, rhs.tpe) =>
             val msg = s"Non-conforming types ${lhs.tpe} and ${rhs.tpe} cannot be compared"
             u.error(tree.pos, msg)
 

--- a/src/main/scala/wartremover/warts/Equal.scala
+++ b/src/main/scala/wartremover/warts/Equal.scala
@@ -1,0 +1,30 @@
+package org.brianmckenna.wartremover
+package warts
+
+object Equal extends WartTraverser {
+
+  def apply(u: WartUniverse): u.Traverser = {
+    import u.universe._
+
+    val EqEqName: TermName = "$eq$eq"
+
+    // We can only compare types that conform
+    def bogus(a: Type, b: Type): Boolean = 
+      !(a <:< b || b <:< a)
+
+    new Traverser {
+      override def traverse(tree: Tree) {
+        tree match {
+
+          case Apply(Select(lhs, EqEqName), List(rhs)) if bogus(lhs.tpe, rhs.tpe) =>
+            val msg = s"Non-conforming types ${lhs.tpe} and ${rhs.tpe} cannot be compared"
+            u.error(tree.pos, msg)
+
+          case _ => super.traverse(tree)
+
+        }          
+      }
+    }
+  }
+
+}

--- a/src/main/scala/wartremover/warts/Equal.scala
+++ b/src/main/scala/wartremover/warts/Equal.scala
@@ -1,12 +1,14 @@
 package org.brianmckenna.wartremover
 package warts
 
+import reflect.NameTransformer
+
 object Equal extends WartTraverser {
 
   def apply(u: WartUniverse): u.Traverser = {
     import u.universe._
 
-    val EqEqName: TermName = "$eq$eq"
+    val EqEqName: TermName = NameTransformer.encode("==")
 
     // We can only compare types that conform
     def bogus(a: Type, b: Type): Boolean = 

--- a/src/test/scala/wartremover/warts/EqualTest.scala
+++ b/src/test/scala/wartremover/warts/EqualTest.scala
@@ -62,4 +62,11 @@ class EqualTest extends FunSuite {
     expectResult(List("Non-conforming types Int and List[Int] cannot be compared"), "result.errors")(result.errors)
     expectResult(List.empty, "result.warnings")(result.warnings)
   }
+  test("works when types differ only in type args") {
+    val result = WartTestTraverser(Equal) {
+      List(1,2) == List(true)
+    }
+    expectResult(List("Non-conforming types List[Int] and List[Boolean] cannot be compared"), "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
+  }
 }

--- a/src/test/scala/wartremover/warts/EqualTest.scala
+++ b/src/test/scala/wartremover/warts/EqualTest.scala
@@ -1,0 +1,65 @@
+package org.brianmckenna.wartremover
+package test
+
+import org.scalatest.FunSuite
+
+import org.brianmckenna.wartremover.warts.Equal
+
+class EqualTest extends FunSuite {
+  test("can't compare non-conforming types (1)") {
+    val result = WartTestTraverser(Equal) {
+      List(1) == Set(1) // scala says false
+    }
+    expectResult(List("Non-conforming types List[Int] and scala.collection.immutable.Set[Int] cannot be compared"), "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
+  }
+  test("can't compare non-conforming types (2)") {
+    val result = WartTestTraverser(Equal) {
+      Vector(1,2,3) == List(1,2,3) // scala says true
+    }
+    expectResult(List("Non-conforming types scala.collection.immutable.Vector[Int] and List[Int] cannot be compared"), "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
+  }
+  test("can't compare non-conforming types (3)") {
+    val result = WartTestTraverser(Equal) {
+      Some(1) == None // scala warns and says false
+    }
+    expectResult(List("Non-conforming types Some[Int] and None.type cannot be compared"), "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
+  }
+  test("ok to compare conforming types (1)") {
+    val result = WartTestTraverser(Equal) {
+      Option(1) == None
+    }
+    expectResult(List.empty, "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
+  }
+  test("ok to compare conforming types (2)") {
+    val result = WartTestTraverser(Equal) {
+      Iterable(1) == List(1) // cringe, but this is ok
+    }
+    expectResult(List.empty, "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
+  }
+  test("implicit conversions don't screw us!") {
+    val result = WartTestTraverser(Equal) {
+      Iterable('a') == "abc" // nope! \o/
+    }
+    expectResult(List("Non-conforming types Iterable[Char] and String(\"abc\") cannot be compared"), "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
+  }
+  test("can't do anything about numeric widening, sorry") {
+    val result = WartTestTraverser(Equal) {
+      1 == 1.0 // sadly you can still do this
+    }
+    expectResult(List.empty, "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
+  }
+  test("works with complex exprs") {
+    val result = WartTestTraverser(Equal) {
+      (1 max 2) == List(3, 4).map(_ + 1)
+    }
+    expectResult(List("Non-conforming types Int and List[Int] cannot be compared"), "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
+  }
+}

--- a/src/test/scala/wartremover/warts/EqualTest.scala
+++ b/src/test/scala/wartremover/warts/EqualTest.scala
@@ -6,58 +6,69 @@ import org.scalatest.FunSuite
 import org.brianmckenna.wartremover.warts.Equal
 
 class EqualTest extends FunSuite {
+  
+  def twice[A](a: A): List[A] = List(a, a)
+  
   test("can't compare non-conforming types (1)") {
     val result = WartTestTraverser(Equal) {
       List(1) == Set(1) // scala says false
+      List(1) equals Set(1) 
     }
-    expectResult(List("Non-conforming types List[Int] and scala.collection.immutable.Set[Int] cannot be compared"), "result.errors")(result.errors)
+    expectResult(twice("Non-conforming types List[Int] and scala.collection.immutable.Set[Int] cannot be compared"), "result.errors")(result.errors)
     expectResult(List.empty, "result.warnings")(result.warnings)
   }
   test("can't compare non-conforming types (2)") {
     val result = WartTestTraverser(Equal) {
       Vector(1,2,3) == List(1,2,3) // scala says true
+      Vector(1,2,3) equals List(1,2,3)
     }
-    expectResult(List("Non-conforming types scala.collection.immutable.Vector[Int] and List[Int] cannot be compared"), "result.errors")(result.errors)
+    expectResult(twice("Non-conforming types scala.collection.immutable.Vector[Int] and List[Int] cannot be compared"), "result.errors")(result.errors)
     expectResult(List.empty, "result.warnings")(result.warnings)
   }
   test("can't compare non-conforming types (3)") {
     val result = WartTestTraverser(Equal) {
       Some(1) == None // scala warns and says false
+      Some(1) equals None 
     }
-    expectResult(List("Non-conforming types Some[Int] and None.type cannot be compared"), "result.errors")(result.errors)
+    expectResult(twice("Non-conforming types Some[Int] and None.type cannot be compared"), "result.errors")(result.errors)
     expectResult(List.empty, "result.warnings")(result.warnings)
   }
   test("ok to compare conforming types (1)") {
     val result = WartTestTraverser(Equal) {
       Option(1) == None
+      Option(1) equals None
     }
     expectResult(List.empty, "result.errors")(result.errors)
     expectResult(List.empty, "result.warnings")(result.warnings)
   }
   test("ok to compare conforming types (2)") {
     val result = WartTestTraverser(Equal) {
-      Iterable(1) == List(1) // cringe, but this is ok
+      Iterable(1) == List(1) 
+      Iterable(1) equals List(1) 
     }
     expectResult(List.empty, "result.errors")(result.errors)
     expectResult(List.empty, "result.warnings")(result.warnings)
   }
   test("implicit conversions don't screw us!") {
     val result = WartTestTraverser(Equal) {
-      Iterable('a') == "abc" // nope! \o/
+      Iterable('a') == "abc"     
+      Iterable('a') equals "abc" 
     }
-    expectResult(List("Non-conforming types Iterable[Char] and String(\"abc\") cannot be compared"), "result.errors")(result.errors)
+    expectResult(twice("Non-conforming types Iterable[Char] and String(\"abc\") cannot be compared"), "result.errors")(result.errors)
     expectResult(List.empty, "result.warnings")(result.warnings)
   }
-  test("can't do anything about numeric widening, sorry") {
+  test("numeric widening sometimes, sorry") {
     val result = WartTestTraverser(Equal) {
-      1 == 1.0 // sadly you can still do this
+      1 == 1.0     // can't do anything about widening here
+      1 equals 1.0 // but we can catch it here
     }
-    expectResult(List.empty, "result.errors")(result.errors)
+    expectResult(List("Non-conforming types Int(1) and Double(1.0) cannot be compared"), "result.errors")(result.errors)
     expectResult(List.empty, "result.warnings")(result.warnings)
   }
   test("works with complex exprs") {
     val result = WartTestTraverser(Equal) {
       (1 max 2) == List(3, 4).map(_ + 1)
+      (1 max 2) equals List(3, 4).map(_ + 1) // Here the RHS is inferred as `Any`
     }
     expectResult(List("Non-conforming types Int and List[Int] cannot be compared"), "result.errors")(result.errors)
     expectResult(List.empty, "result.warnings")(result.warnings)
@@ -65,8 +76,10 @@ class EqualTest extends FunSuite {
   test("works when types differ only in type args") {
     val result = WartTestTraverser(Equal) {
       List(1,2) == List(true)
+      List(1,2) equals List(true)
     }
-    expectResult(List("Non-conforming types List[Int] and List[Boolean] cannot be compared"), "result.errors")(result.errors)
+    expectResult(twice("Non-conforming types List[Int] and List[Boolean] cannot be compared"), "result.errors")(result.errors)
     expectResult(List.empty, "result.warnings")(result.warnings)
   }
+
 }


### PR DESCRIPTION
This is in response to #45.

This wart disables `==` for operands of non-conforming types. It disables, for instance, comparison between `List` and `Set`, but allows comparison between `Option[Int]` and `None`. It would be nice, if the types are not equal, to require the supertype to be abstract; however I have not been able to figure out how to determine this (the `TypeSymbol` always claims to be non-abstract).

Note that implementing this wart for `equals` is, oddly, a different situation. In the expression `(1 max 2) == List(3, 4).map(_ + 1)` the RHS has type `List[Int]`, but for `equals` the RHS is inferred as `Any ?` (which of course conforms with the LHS). Go figure.

Anyway I thought I would throw this out as a starting point.
