### PR TITLE
Fix case classes with varargs

### DIFF
--- a/src/main/scala/wartremover/warts/Null.scala
+++ b/src/main/scala/wartremover/warts/Null.scala
@@ -6,6 +6,7 @@ object Null extends WartTraverser {
     import u.universe._
 
     val UnapplyName: TermName = "unapply"
+    val UnapplySeqName: TermName = "unapplySeq"
     val xmlSymbols = (classOf[scala.xml.Elem]
       :: classOf[scala.xml.NamespaceBinding]
       :: Nil) map (c => rootMirror.staticClass(c.getCanonicalName))
@@ -25,7 +26,7 @@ object Null extends WartTraverser {
             }
             traverse(self)
             stats filter {
-              case dd@DefDef(_, UnapplyName, _, _, _, _) if isSynthetic(u)(dd) =>
+              case dd@DefDef(_, UnapplyName | UnapplySeqName, _, _, _, _) if isSynthetic(u)(dd) =>
                 false
               case _ =>
                 true

--- a/src/test/scala/wartremover/safe/CaseClassTest.scala
+++ b/src/test/scala/wartremover/safe/CaseClassTest.scala
@@ -14,4 +14,11 @@ class CaseClassTest extends FunSuite {
     expectResult(List.empty, "result.errors")(result.errors)
     expectResult(List.empty, "result.warnings")(result.warnings)
   }
+  test("vararg case classes still work") {
+    val result = WartTestTraverser(Unsafe) {
+      case class A(a: Int*)
+    }
+    expectResult(List.empty, "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
+  }
 }


### PR DESCRIPTION
Before, `case class A(a: Int*)` triggered the `Null` wart.
