### PR TITLE
Let the user choose warnings over errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ addCompilerPlugin("org.brianmckenna" %% "wartremover" % "0.7")
 scalacOptions in (Compile, compile) += "-P:wartremover:traverser:org.brianmckenna.wartremover.warts.Unsafe"
 ```
 
+By default, WartRemover generates compile-time errors. If you want to be warned only, use the `only-warn` option:
+
+```scala
+scalacOptions in (Compile, compile) += "-P:wartremover:only-warn,wartremover:traverser:org.brianmckenna.wartremover.warts.Unsafe"
+```
+
 ### Macros
 
 You can make any wart into a macro, like so:


### PR DESCRIPTION
Solves #5.

Usage:

```
-P:wartremover:only-warn,wartremover:traverser:org.brianmckenna.wartremover.warts.Unsafe
```
