### PR TITLE
add new JavaConversions and MutableDataStructure WartTraversers

### DIFF
--- a/src/main/scala/wartremover/warts/JavaConversions.scala
+++ b/src/main/scala/wartremover/warts/JavaConversions.scala
@@ -1,0 +1,22 @@
+package org.brianmckenna.wartremover
+package warts
+
+object JavaConversions extends WartTraverser {
+  def apply(u: WartUniverse): u.Traverser = {
+    import u.universe._
+
+    val javaConversions = rootMirror.staticModule("scala.collection.JavaConversions")
+
+    new Traverser {
+      override def traverse(tree: Tree) {
+        tree match {
+          case Select(tpt, _) if tpt.tpe.contains(javaConversions) => {
+            u.error(tree.pos, "scala.collection.JavaConversions is disabled - use scala.collection.JavaConverters instead")
+          }
+          case _ =>
+        }
+        super.traverse(tree)
+      }
+    }
+  }
+}

--- a/src/main/scala/wartremover/warts/MutableDataStructures.scala
+++ b/src/main/scala/wartremover/warts/MutableDataStructures.scala
@@ -1,0 +1,21 @@
+package org.brianmckenna.wartremover
+package warts
+
+object MutableDataStructures extends WartTraverser {
+  def apply(u: WartUniverse): u.Traverser = {
+    import u.universe._
+
+    val mutablePackage = rootMirror.staticPackage("scala.collection.mutable")
+
+    new Traverser {
+      override def traverse(tree: Tree) {
+        tree match {
+          case Select(tpt, _) if tpt.tpe.contains(mutablePackage) && tpt.tpe.termSymbol.isPackage =>
+            u.error(tree.pos, "scala.collection.mutable package is disabled -  use java.util instead")
+          case _ =>
+        }
+        super.traverse(tree)
+      }
+    }
+  }
+}

--- a/src/test/scala/wartremover/warts/JavaConversionsTest.scala
+++ b/src/test/scala/wartremover/warts/JavaConversionsTest.scala
@@ -1,0 +1,28 @@
+package org.brianmckenna.wartremover
+package test
+
+import org.scalatest.FunSuite
+
+import org.brianmckenna.wartremover.warts.JavaConversions
+
+class JavaConversionsTest extends FunSuite {
+   test("handle explicit method reference") {
+    val result = WartTestTraverser(JavaConversions) {
+      def ff[A](it: Iterable[A]) = collection.JavaConversions.asJavaCollection(it)
+      
+    }
+    expectResult(List("scala.collection.JavaConversions is disabled - use scala.collection.JavaConverters instead"), "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
+   
+  }  
+  test("disable scala.collection.JavaConversions when referenced in an import") {
+    val result = WartTestTraverser(JavaConversions) {
+      import scala.collection.JavaConversions._
+      val x: java.util.List[Int]= new java.util.ArrayList[Int]
+      val y: Seq[Int] = x
+    }
+    expectResult(List("scala.collection.JavaConversions is disabled - use scala.collection.JavaConverters instead"), "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
+   
+  } 
+}

--- a/src/test/scala/wartremover/warts/MutableDataStructuresTest.scala
+++ b/src/test/scala/wartremover/warts/MutableDataStructuresTest.scala
@@ -1,0 +1,23 @@
+package org.brianmckenna.wartremover
+package test
+
+import org.scalatest.FunSuite
+
+import org.brianmckenna.wartremover.warts.MutableDataStructures
+
+class MutableDataStructuresTest extends FunSuite {
+  test("disable scala.collection.mutable._ when referenced") {
+    val result = WartTestTraverser(MutableDataStructures) {
+      var x = scala.collection.mutable.HashMap("key" -> "value")
+    }
+    expectResult(List("scala.collection.mutable package is disabled -  use java.util instead"), "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
+  }
+  test("ignore immutable collections") {
+    val result = WartTestTraverser(MutableDataStructures) {
+      var x = Map("key" -> "value")
+    }
+    expectResult(List.empty, "result.errors")(result.errors)
+    expectResult(List.empty, "result.warnings")(result.warnings)
+  }
+}


### PR DESCRIPTION
I wrote a short tutorial about wartremover [here](http://tech.kinja.com/wartremover-a-flexible-scala-code-linting-tool-1540761622) 
As part of that exercise I created two new checkers that you might find useful:
- `JavaConversions`: disabling `scala.collection.JavaConversions`
- `MutableDataStructure`: disabling `scala.collection.mutable._`

(Please note, I did not add `JavaConversions` and `MutableDataStructure` to `org.brianmckenna.wartremover.Unsafe` since these might be too opinionated to be part of the default list)
