### PR TITLE
Cross-build to 2.11.0-RC3, cleaner build.sbt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: scala
 scala:
   - 2.10.3
-  - 2.11.0-RC1
+  - 2.11.0-RC3

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ organization := "org.brianmckenna"
 
 scalaVersion := "2.10.3"
 
-crossScalaVersions := Seq("2.10.3", "2.11.0-RC1")
+crossScalaVersions := Seq("2.10.3", "2.11.0-RC3")
 
 crossVersion := CrossVersion.binary
 
@@ -39,15 +39,18 @@ resolvers += Resolver.sonatypeRepo("snapshots")
 
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.0-M3" cross CrossVersion.full)
 
-libraryDependencies ++= (if (scalaVersion.value.startsWith("2.10")) {
-  Seq("org.scalamacros" % "quasiquotes" % "2.0.0-M3" cross CrossVersion.full)
-} else {
-  Seq()
-})
+libraryDependencies := {
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, 10)) =>
+      libraryDependencies.value :+ ("org.scalamacros" % "quasiquotes" % "2.0.0-M3" cross CrossVersion.full)
+    case _ =>
+      libraryDependencies.value
+  }
+}
 
 libraryDependencies ++= Seq(
   "org.scala-lang" % "scala-compiler" % scalaVersion.value,
-  "org.scalatest" %% "scalatest" % "2.1.0" % "test"
+  "org.scalatest" %% "scalatest" % "2.1.2" % "test"
 )
 
 scalacOptions in Test <++= packageBin in Compile map { pluginJar => Seq(


### PR DESCRIPTION
Hi, it’s me again :) Updated to 2.11.0-RC3.
I would be really grateful if you could cross-publish this, as _Wartremover_ is the only non-`2.11` dependency in my project (https://github.com/macroid/macroid), and I want to cross-publish the upcoming new version soon.
