### PR TITLE
Update to paradise-M7 and Scala 2.10.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: scala
 scala:
   - 2.10.4
-  - 2.11.0-RC3
+  - 2.11.0-RC4

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ organization := "org.brianmckenna"
 
 scalaVersion := "2.10.4"
 
-crossScalaVersions := Seq("2.10.4", "2.11.0-RC3")
+crossScalaVersions := Seq("2.10.4", "2.11.0-RC4")
 
 crossVersion := CrossVersion.binary
 
@@ -50,7 +50,7 @@ libraryDependencies := {
 
 libraryDependencies ++= Seq(
   "org.scala-lang" % "scala-compiler" % scalaVersion.value,
-  "org.scalatest" %% "scalatest" % "2.1.2" % "test"
+  "org.scalatest" %% "scalatest" % "2.1.3" % "test"
 )
 
 scalacOptions in Test <++= packageBin in Compile map { pluginJar => Seq(


### PR DESCRIPTION
Hi,

Yet another update, this time — to accommodate changes in `paradise-M7`. You can find the details [on the scalamacros site](http://scalamacros.org/news/2014/04/03/macro-paradise-2.0.0-M7.html) and in [my google group post](https://groups.google.com/forum/#!topic/scala-internals/V9krF0y5y_g). The update prevents _Wartremover_ from conflicting with other libraries, which could be observed before because of the full cross-versioning of `quasiquotes`. While we are at it, I also updated to Scala `2.10.4`. `2.11.0-RC4` is out as well, but unfortunately `scalatest` is not published yet.
