### PR TITLE
Add Nothing wart to Unsafe

### DIFF
--- a/src/main/scala/wartremover/warts/Unsafe.scala
+++ b/src/main/scala/wartremover/warts/Unsafe.scala
@@ -9,6 +9,7 @@ object Unsafe extends WartTraverser {
     EitherProjectionPartial,
     IsInstanceOf,
     NonUnitStatements,
+    Nothing,
     Null,
     OptionPartial,
     Product,


### PR DESCRIPTION
Why was it the only one skipped among the five then-existing warts in
https://github.com/typelevel/wartremover/commit/f022afd1c6098eaa73fc8cc44dd01f91ec50e932#diff-f26273ba31398d4d8a36ba7c1c91f7abR5?
