### PR TITLE
Fixes #215 Optionally exclude macro expansions from checks

### DIFF
--- a/sbt-plugin/src/main/scala/wartremover/WartRemover.scala
+++ b/sbt-plugin/src/main/scala/wartremover/WartRemover.scala
@@ -10,6 +10,7 @@ object WartRemover extends sbt.AutoPlugin {
     val wartremoverWarnings = wartremover.wartremoverWarnings
     val wartremoverExcluded = wartremover.wartremoverExcluded
     val wartremoverClasspaths = wartremover.wartremoverClasspaths
+    val wartremoverNoMacros = wartremover.wartremoverNoMacros
     val Wart = wartremover.Wart
     val Warts = wartremover.Warts
   }

--- a/sbt-plugin/src/main/scala/wartremover/package.scala
+++ b/sbt-plugin/src/main/scala/wartremover/package.scala
@@ -7,6 +7,7 @@ package object wartremover {
   val wartremoverWarnings = settingKey[Seq[Wart]]("List of Warts that will be reported as compilation warnings.")
   val wartremoverExcluded = settingKey[Seq[File]]("List of files to be excluded from all checks.")
   val wartremoverClasspaths = settingKey[Seq[String]]("List of classpaths for custom Warts")
+  val wartremoverNoMacros = settingKey[Boolean]("Exclude macro expansions from checks.")
 
   lazy val wartremoverSettings: Seq[sbt.Def.Setting[_]] = Seq(
     wartremoverErrors := Seq.empty,
@@ -20,7 +21,8 @@ package object wartremover {
     derive(scalacOptions ++= wartremoverErrors.value.distinct map (w => s"-P:wartremover:traverser:${w.clazz}")),
     derive(scalacOptions ++= wartremoverWarnings.value.distinct filterNot (wartremoverErrors.value contains _) map (w => s"-P:wartremover:only-warn-traverser:${w.clazz}")),
     derive(scalacOptions ++= wartremoverExcluded.value.distinct map (c => s"-P:wartremover:excluded:${c.getAbsolutePath}")),
-    derive(scalacOptions ++= wartremoverClasspaths.value.distinct map (cp => s"-P:wartremover:cp:$cp"))
+    derive(scalacOptions ++= wartremoverClasspaths.value.distinct map (cp => s"-P:wartremover:cp:$cp")),
+    derive(scalacOptions += s"-P:wartremover:no-macros:${ wartremoverNoMacros.value }")
   ))
 
   // Workaround for typelevel/wartremover#123


### PR DESCRIPTION
Introduces a `no-macros` plugin argument and `wartremoverNoMacros`
setting which is consulted at the same point as suppression
annotations.

That looks like the cleanest way to short-circuit traversal.

The config flag is communicated through a member of `WartUniverse`,
but the traverser could also look up the plugin through `global`
if it's desirable to keep the `WartUniverse` from expanding.

A mechanism is required for automated testing with different
plugin configurations.
