### PR TITLE
Fixes #158 No error on Any lower bound

### DIFF
--- a/core/src/test/scala/wartremover/warts/AnyTest.scala
+++ b/core/src/test/scala/wartremover/warts/AnyTest.scala
@@ -23,4 +23,12 @@ class AnyTest extends FunSuite {
     assertResult(List.empty, "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
+  test("Any can be inferred if it must be") {
+    val result = WartTestTraverser(Any) {
+      def f[A >: Any] = 42
+      f
+    }
+    assertResult(List.empty, "result.errors")(result.errors)
+    assertResult(List.empty, "result.warnings")(result.warnings)
+  }
 }


### PR DESCRIPTION
Allow the idiom `def f[A >: Any]` to subvert the `Any` rule.

This fix seems to require ugly casting to narrower compiler interfaces.
