### PR TITLE
Fix has annotation

### DIFF
--- a/core/src/main/scala/wartremover/WartTraverser.scala
+++ b/core/src/main/scala/wartremover/WartTraverser.scala
@@ -87,7 +87,10 @@ trait WartTraverser {
   def hasWartAnnotation(u: WartUniverse)(tree: u.universe.Tree) = {
     import u.universe._
     tree match {
-      case t: ValOrDefDef => t.symbol.annotations.exists(isWartAnnotation(u))
+      case t: ValOrDefDef =>
+        t.symbol.annotations.exists(isWartAnnotation(u)) ||
+        (t.symbol != null && t.symbol.isTerm && t.symbol.asTerm.isAccessor &&
+          t.symbol.asTerm.accessed.annotations.exists(isWartAnnotation(u)))
       case t: ImplDef => t.symbol.annotations.exists(isWartAnnotation(u))
       case t => false
     }


### PR DESCRIPTION
Scala compiler does not copy the annotations over to the setters when generating them. This PR makes sure to look at them when searching for Wart annotations.

It only looks at the annotations of an accessed field if the tree to be tested is an accessor method.