### PR TITLE
Fix a crash in ImplicitParameter

### DIFF
--- a/core/src/main/scala/wartremover/warts/ImplicitParameter.scala
+++ b/core/src/main/scala/wartremover/warts/ImplicitParameter.scala
@@ -28,9 +28,13 @@ object ImplicitParameter extends WartTraverser {
 
           case DefDef(_, _, tparams, paramss, _, _) if !isSynthetic(u)(tree) && {
             val tsymbols = tparams.map(_.symbol).toSet
-            paramss.last.exists { x =>
-              x.symbol.isImplicit && !x.symbol.isSynthetic && !isImplicitParamTypeInTparams(x, tsymbols)
-            }
+
+            def isManualImplicit(x: ValDef): Boolean =
+              x.symbol.isImplicit &&
+                !x.symbol.isSynthetic &&
+                !isImplicitParamTypeInTparams(x, tsymbols)
+
+            paramss.lastOption.fold(false)(_.exists(isManualImplicit))
           } =>
             u.error(tree.pos, "Implicit parameters are disabled")
 

--- a/core/src/test/scala/wartremover/warts/ImplicitParameterTest.scala
+++ b/core/src/test/scala/wartremover/warts/ImplicitParameterTest.scala
@@ -29,6 +29,13 @@ class ImplicitParameterTest extends FunSuite with ResultAssertions {
     assertEmpty(result)
   }
 
+  test("Defs without parameters don't lead to a crash") {
+    val result = WartTestTraverser(ImplicitParameter) {
+      def f = ()
+    }
+    assertEmpty(result)
+  }
+
   test("ImplicitParameter wart obeys SuppressWarnings") {
     val result = WartTestTraverser(ImplicitParameter) {
       @SuppressWarnings(Array("org.wartremover.warts.ImplicitParameter"))


### PR DESCRIPTION
We can have methods without parameter lists, too.

Fixes #312