### PR TITLE
Improved error/warning messages

### DIFF
--- a/core/src/main/scala/wartremover/Plugin.scala
+++ b/core/src/main/scala/wartremover/Plugin.scala
@@ -62,16 +62,16 @@ class Plugin(val global: Global) extends tools.nsc.plugins.Plugin {
         val isExcluded = excludedFiles contains unit.source.file.absolute.path
 
         if (!isExcluded) {
-          def wartUniverse(onlyWarn: Boolean) = new WartUniverse {
+          def wartUniverse(t: WartTraverser, onlyWarn: Boolean) = new WartUniverse(t) {
             val universe: global.type = global
             def error(pos: Position, message: String) =
-              if (onlyWarn) global.reporter.warning(pos, message)
-              else global.reporter.error(pos, message)
-            def warning(pos: Position, message: String) = global.reporter.warning(pos, message)
+              if (onlyWarn) global.reporter.warning(pos, decorateMessage(message))
+              else global.reporter.error(pos, decorateMessage(message))
+            def warning(pos: Position, message: String) = global.reporter.warning(pos, decorateMessage(message))
           }
 
           def go(ts: List[WartTraverser], onlyWarn: Boolean) =
-            ts.foreach(_(wartUniverse(onlyWarn)).traverse(unit.body))
+            ts.foreach(t => t(wartUniverse(t, onlyWarn)).traverse(unit.body))
 
           go(traversers, onlyWarn = false)
           go(onlyWarnTraversers, onlyWarn = true)

--- a/core/src/main/scala/wartremover/WartTraverser.scala
+++ b/core/src/main/scala/wartremover/WartTraverser.scala
@@ -111,10 +111,10 @@ object WartTraverser {
 
 abstract class WartUniverse(t: WartTraverser) {
   val universe: Universe
-  private[this] lazy val messagePrefix = s"[wartremover:${t.className}] "
+  private[this] lazy val messagePrefix = s"[${t.className}] "
   type Traverser = universe.Traverser
   type TypeTag[T] = universe.TypeTag[T]
   def error(pos: universe.Position, message: String): Unit
   def warning(pos: universe.Position, message: String): Unit
-  protected def decorateMessage(message: String): String = s"${messagePrefix}message"
+  protected def decorateMessage(message: String): String = s"$messagePrefix$message"
 }

--- a/core/src/main/scala/wartremover/test/TestMacro.scala
+++ b/core/src/main/scala/wartremover/test/TestMacro.scala
@@ -18,10 +18,10 @@ object WartTestTraverser {
     var errors = collection.mutable.ListBuffer[String]()
     var warnings = collection.mutable.ListBuffer[String]()
 
-    object MacroTestUniverse extends WartUniverse {
+    object MacroTestUniverse extends WartUniverse(traverser) {
       val universe: c.universe.type = c.universe
-      def error(pos: universe.Position, message: String) = errors += message
-      def warning(pos: universe.Position, message: String) = warnings += message
+      def error(pos: universe.Position, message: String) = errors += decorateMessage(message)
+      def warning(pos: universe.Position, message: String) = warnings += decorateMessage(message)
     }
 
     traverser(MacroTestUniverse).traverse(a.tree)

--- a/core/src/test/scala/wartremover/warts/Any2StringAddTest.scala
+++ b/core/src/test/scala/wartremover/warts/Any2StringAddTest.scala
@@ -10,7 +10,7 @@ class Any2StringAddTest extends FunSuite with ResultAssertions {
     val result = WartTestTraverser(Any2StringAdd) {
       {} + "lol"
     }
-    assertError(result)("Scala inserted an any2stringadd call")
+    assertError(result)(s"[org.wartremover.warts.Any2StringAdd] Scala inserted an any2stringadd call")
   }
   test("any2stringadd wart obeys SuppressWarnings") {
     val result = WartTestTraverser(Any2StringAdd) {

--- a/core/src/test/scala/wartremover/warts/AnyTest.scala
+++ b/core/src/test/scala/wartremover/warts/AnyTest.scala
@@ -11,7 +11,7 @@ class AnyTest extends FunSuite with ResultAssertions {
       val x = readf1("{0}")
       x
     }
-    assertError(result)("Inferred type containing Any")
+    assertError(result)("[org.wartremover.warts.Any] Inferred type containing Any")
   }
   test("Any wart obeys SuppressWarnings") {
     val result = WartTestTraverser(Any) {

--- a/core/src/test/scala/wartremover/warts/AsInstanceOfTest.scala
+++ b/core/src/test/scala/wartremover/warts/AsInstanceOfTest.scala
@@ -10,7 +10,7 @@ class AsInstanceOfTest extends FunSuite with ResultAssertions {
     val result = WartTestTraverser(AsInstanceOf) {
       "abc".asInstanceOf[String]
     }
-    assertError(result)("asInstanceOf is disabled")
+    assertError(result)("[org.wartremover.warts.AsInstanceOf] asInstanceOf is disabled")
   }
   test("asInstanceOf wart obeys SuppressWarnings") {
     val result = WartTestTraverser(AsInstanceOf) {

--- a/core/src/test/scala/wartremover/warts/DefaultArgumentsTest.scala
+++ b/core/src/test/scala/wartremover/warts/DefaultArgumentsTest.scala
@@ -10,7 +10,7 @@ class DefaultArgumentsTest extends FunSuite with ResultAssertions {
     val result = WartTestTraverser(DefaultArguments) {
       def x(y: Int = 4) = y
     }
-    assertError(result)("Function has default arguments")
+    assertError(result)("[org.wartremover.warts.DefaultArguments] Function has default arguments")
   }
   test("Default arguments wart obeys SuppressWarnings") {
     val result = WartTestTraverser(DefaultArguments) {

--- a/core/src/test/scala/wartremover/warts/EitherProjectionPartialTest.scala
+++ b/core/src/test/scala/wartremover/warts/EitherProjectionPartialTest.scala
@@ -10,25 +10,25 @@ class EitherProjectionPartialTest extends FunSuite with ResultAssertions {
     val result = WartTestTraverser(EitherProjectionPartial) {
       println(Left(1).left.get)
     }
-    assertError(result)("LeftProjection#get is disabled - use LeftProjection#toOption instead")
+    assertError(result)("[org.wartremover.warts.EitherProjectionPartial] LeftProjection#get is disabled - use LeftProjection#toOption instead")
   }
   test("can't use LeftProjection#get on Right") {
     val result = WartTestTraverser(EitherProjectionPartial) {
       println(Right(1).left.get)
     }
-    assertError(result)("LeftProjection#get is disabled - use LeftProjection#toOption instead")
+    assertError(result)("[org.wartremover.warts.EitherProjectionPartial] LeftProjection#get is disabled - use LeftProjection#toOption instead")
   }
   test("can't use RightProjection#get on Left") {
     val result = WartTestTraverser(EitherProjectionPartial) {
       println(Left(1).right.get)
     }
-    assertError(result)("RightProjection#get is disabled - use RightProjection#toOption instead")
+    assertError(result)("[org.wartremover.warts.EitherProjectionPartial] RightProjection#get is disabled - use RightProjection#toOption instead")
   }
   test("can't use RightProjection#get on Right") {
     val result = WartTestTraverser(EitherProjectionPartial) {
       println(Right(1).right.get)
     }
-    assertError(result)("RightProjection#get is disabled - use RightProjection#toOption instead")
+    assertError(result)("[org.wartremover.warts.EitherProjectionPartial] RightProjection#get is disabled - use RightProjection#toOption instead")
   }
   test("EitherProjectionPartial wart obeys SuppressWarnings") {
     val result = WartTestTraverser(EitherProjectionPartial) {

--- a/core/src/test/scala/wartremover/warts/EnumerationTest.scala
+++ b/core/src/test/scala/wartremover/warts/EnumerationTest.scala
@@ -13,7 +13,7 @@ class EnumerationTest extends FunSuite with ResultAssertions {
         val Blue = Value
       }
     }
-    assertError(result)("Enumeration is disabled - use case objects instead")
+    assertError(result)("[org.wartremover.warts.Enumeration] Enumeration is disabled - use case objects instead")
   }
   test("can't declare Enumeration objects") {
     val result = WartTestTraverser(EnumerationWart) {
@@ -22,7 +22,7 @@ class EnumerationTest extends FunSuite with ResultAssertions {
         val Blue = Value
       }
     }
-    assertError(result)("Enumeration is disabled - use case objects instead")
+    assertError(result)("[org.wartremover.warts.Enumeration] Enumeration is disabled - use case objects instead")
   }
   test("can use user-defined Enumeration traits") {
     val result = WartTestTraverser(EnumerationWart) {

--- a/core/src/test/scala/wartremover/warts/EqualsTest.scala
+++ b/core/src/test/scala/wartremover/warts/EqualsTest.scala
@@ -13,7 +13,7 @@ class EqualsTest extends FunSuite with ResultAssertions {
       i == s
       i != s
     }
-    assertResult(List("== is disabled - use === or equivalent instead", "!= is disabled - use =/= or equivalent instead"), "result.errors")(result.errors)
+    assertResult(List("[org.wartremover.warts.Equals] == is disabled - use === or equivalent instead", "[org.wartremover.warts.Equals] != is disabled - use =/= or equivalent instead"), "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
   test("can't use == or != on classes") {
@@ -22,7 +22,7 @@ class EqualsTest extends FunSuite with ResultAssertions {
 		new Foo(5) == new Foo(4)
 		new Foo(5) != new Foo(4)
     }
-    assertResult(List("== is disabled - use === or equivalent instead", "!= is disabled - use =/= or equivalent instead"), "result.errors")(result.errors)
+    assertResult(List("[org.wartremover.warts.Equals] == is disabled - use === or equivalent instead", "[org.wartremover.warts.Equals] != is disabled - use =/= or equivalent instead"), "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
   test("can't use == or != on case classes") {
@@ -31,7 +31,7 @@ class EqualsTest extends FunSuite with ResultAssertions {
 		Foo(5) == Foo(4)
 		Foo(5) != Foo(4)
     }
-    assertResult(List("== is disabled - use === or equivalent instead", "!= is disabled - use =/= or equivalent instead"), "result.errors")(result.errors)
+    assertResult(List("[org.wartremover.warts.Equals] == is disabled - use === or equivalent instead", "[org.wartremover.warts.Equals] != is disabled - use =/= or equivalent instead"), "result.errors")(result.errors)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
   test("Equals wart obeys SuppressWarnings") {

--- a/core/src/test/scala/wartremover/warts/ExplicitImplicitTypesTest.scala
+++ b/core/src/test/scala/wartremover/warts/ExplicitImplicitTypesTest.scala
@@ -10,7 +10,7 @@ class ExplicitImplicitTypesTest extends FunSuite with ResultAssertions {
     val result = WartTestTraverser(ExplicitImplicitTypes) {
       implicit val foo = 5
     }
-    assertError(result)("implicit definitions must have an explicit type ascription")
+    assertError(result)("[org.wartremover.warts.ExplicitImplicitTypes] implicit definitions must have an explicit type ascription")
   }
 
   test("can't declare implicit defs without a type ascription") {
@@ -20,7 +20,7 @@ class ExplicitImplicitTypesTest extends FunSuite with ResultAssertions {
       implicit def baz(i: Int) = 5
       implicit def qux[I](i: I) = 5
     }
-    assertErrors(result)("implicit definitions must have an explicit type ascription", 4)
+    assertErrors(result)("[org.wartremover.warts.ExplicitImplicitTypes] implicit definitions must have an explicit type ascription", 4)
   }
 
   test("can declare implicit classes") {

--- a/core/src/test/scala/wartremover/warts/FinalCaseClassTest.scala
+++ b/core/src/test/scala/wartremover/warts/FinalCaseClassTest.scala
@@ -10,7 +10,7 @@ class FinalCaseClassTest extends FunSuite with ResultAssertions {
     val result = WartTestTraverser(FinalCaseClass) {
       case class Foo(i: Int)
     }
-    assertError(result)("case classes must be final")
+    assertError(result)("[org.wartremover.warts.FinalCaseClass] case classes must be final")
   }
 
   test("can declare final case classes") {

--- a/core/src/test/scala/wartremover/warts/FinalValTest.scala
+++ b/core/src/test/scala/wartremover/warts/FinalValTest.scala
@@ -12,7 +12,7 @@ class FinalValTest extends FunSuite with ResultAssertions {
         final val v = 1
       }
     }
-    assertError(result)("final val is disabled - use non-final val or final def or add type ascription")
+    assertError(result)("[org.wartremover.warts.FinalVal] final val is disabled - use non-final val or final def or add type ascription")
   }
 
   test("final val alternatives are enabled") {

--- a/core/src/test/scala/wartremover/warts/ImplicitConversionTest.scala
+++ b/core/src/test/scala/wartremover/warts/ImplicitConversionTest.scala
@@ -12,7 +12,7 @@ class ImplicitConversionTest extends FunSuite with ResultAssertions {
         implicit def int2Array(i: Int): Array[String] = Array.fill(i)("?")
       }
     }
-    assertError(result)("Implicit conversion is disabled")
+    assertError(result)("[org.wartremover.warts.ImplicitConversion] Implicit conversion is disabled")
   }
 
   test("Non-public implicit conversion is enabled") {

--- a/core/src/test/scala/wartremover/warts/ImplicitParameterTest.scala
+++ b/core/src/test/scala/wartremover/warts/ImplicitParameterTest.scala
@@ -12,7 +12,7 @@ class ImplicitParameterTest extends FunSuite with ResultAssertions {
 
       def f2[A]()(implicit a: A) = ()
     }
-    assertErrors(result)("Implicit parameters are disabled", 2)
+    assertErrors(result)("[org.wartremover.warts.ImplicitParameter] Implicit parameters are disabled", 2)
   }
 
   test("Context bounds are enabled") {

--- a/core/src/test/scala/wartremover/warts/IsInstanceOfTest.scala
+++ b/core/src/test/scala/wartremover/warts/IsInstanceOfTest.scala
@@ -10,7 +10,7 @@ class IsInstanceOfTest extends FunSuite with ResultAssertions {
     val result = WartTestTraverser(IsInstanceOf) {
       "abc".isInstanceOf[String]
     }
-    assertError(result)("isInstanceOf is disabled")
+    assertError(result)("[org.wartremover.warts.IsInstanceOf] isInstanceOf is disabled")
   }
   test("isInstanceOf wart obeys SuppressWarnings") {
     val result = WartTestTraverser(IsInstanceOf) {

--- a/core/src/test/scala/wartremover/warts/JavaConversionsTest.scala
+++ b/core/src/test/scala/wartremover/warts/JavaConversionsTest.scala
@@ -10,7 +10,7 @@ class JavaConversionsTest extends FunSuite with ResultAssertions {
     val result = WartTestTraverser(JavaConversions) {
       def ff[A](it: Iterable[A]) = collection.JavaConversions.asJavaCollection(it)
     }
-    assertError(result)("scala.collection.JavaConversions is disabled - use scala.collection.JavaConverters instead")
+    assertError(result)("[org.wartremover.warts.JavaConversions] scala.collection.JavaConversions is disabled - use scala.collection.JavaConverters instead")
   }
   test("disable scala.collection.JavaConversions when referenced in an import") {
     val result = WartTestTraverser(JavaConversions) {
@@ -18,7 +18,7 @@ class JavaConversionsTest extends FunSuite with ResultAssertions {
       val x: java.util.List[Int]= new java.util.ArrayList[Int]
       val y: Seq[Int] = x
     }
-    assertError(result)("scala.collection.JavaConversions is disabled - use scala.collection.JavaConverters instead")
+    assertError(result)("[org.wartremover.warts.JavaConversions] scala.collection.JavaConversions is disabled - use scala.collection.JavaConverters instead")
   }
   test("JavaConversions wart obeys SuppressWarnings") {
     val result = WartTestTraverser(JavaConversions) {

--- a/core/src/test/scala/wartremover/warts/LeakingSealedTest.scala
+++ b/core/src/test/scala/wartremover/warts/LeakingSealedTest.scala
@@ -11,7 +11,7 @@ class LeakingSealedTest extends FunSuite with ResultAssertions {
       sealed trait t
       class c extends t
     }
-    assertError(result)("Descendants of a sealed type must be final or sealed")
+    assertError(result)("[org.wartremover.warts.LeakingSealed] Descendants of a sealed type must be final or sealed")
   }
 
   test("Final or sealed descendants of a sealed type are allowed") {

--- a/core/src/test/scala/wartremover/warts/ListTest.scala
+++ b/core/src/test/scala/wartremover/warts/ListTest.scala
@@ -10,49 +10,49 @@ class ListTest extends FunSuite with ResultAssertions {
     val result = WartTestTraverser(ListOps) {
       println(List(1).head)
     }
-    assertError(result)("List#head is disabled - use List#headOption instead")
+    assertError(result)("[org.wartremover.warts.ListOps] List#head is disabled - use List#headOption instead")
   }
 
   test("can't use List#tail on List") {
     val result = WartTestTraverser(ListOps) {
       println(List().tail)
     }
-    assertError(result)("List#tail is disabled - use List#drop(1) instead")
+    assertError(result)("[org.wartremover.warts.ListOps] List#tail is disabled - use List#drop(1) instead")
   }
 
   test("can't use List#init on List") {
     val result = WartTestTraverser(ListOps) {
       println(List().init)
     }
-    assertError(result)("List#init is disabled - use List#dropRight(1) instead")
+    assertError(result)("[org.wartremover.warts.ListOps] List#init is disabled - use List#dropRight(1) instead")
   }
 
   test("can't use List#last on List") {
     val result = WartTestTraverser(ListOps) {
       println(List().last)
     }
-    assertError(result)("List#last is disabled - use List#lastOption instead")
+    assertError(result)("[org.wartremover.warts.ListOps] List#last is disabled - use List#lastOption instead")
   }
 
   test("can't use List#reduce on List") {
     val result = WartTestTraverser(ListOps) {
       println(List.empty[Int].reduce(_ + _))
     }
-    assertError(result)("List#reduce is disabled - use List#reduceOption or List#fold instead")
+    assertError(result)("[org.wartremover.warts.ListOps] List#reduce is disabled - use List#reduceOption or List#fold instead")
   }
 
   test("can't use List#reduceLeft on List") {
     val result = WartTestTraverser(ListOps) {
       println(List.empty[Int].reduceLeft(_ + _))
     }
-    assertError(result)("List#reduceLeft is disabled - use List#reduceLeftOption or List#foldLeft instead")
+    assertError(result)("[org.wartremover.warts.ListOps] List#reduceLeft is disabled - use List#reduceLeftOption or List#foldLeft instead")
   }
 
   test("can't use List#reduceRight on List") {
     val result = WartTestTraverser(ListOps) {
       println(List.empty[Int].reduceRight(_ + _))
     }
-    assertError(result)("List#reduceRight is disabled - use List#reduceRightOption or List#foldRight instead")
+    assertError(result)("[org.wartremover.warts.ListOps] List#reduceRight is disabled - use List#reduceRightOption or List#foldRight instead")
   }
 
   test("ListOps wart obeys SuppressWarnings") {

--- a/core/src/test/scala/wartremover/warts/MutableDataStructuresTest.scala
+++ b/core/src/test/scala/wartremover/warts/MutableDataStructuresTest.scala
@@ -10,7 +10,7 @@ class MutableDataStructuresTest extends FunSuite with ResultAssertions {
     val result = WartTestTraverser(MutableDataStructures) {
       var x = scala.collection.mutable.HashMap("key" -> "value")
     }
-    assertError(result)("scala.collection.mutable package is disabled")
+    assertError(result)("[org.wartremover.warts.MutableDataStructures] scala.collection.mutable package is disabled")
   }
   test("ignore immutable collections") {
     val result = WartTestTraverser(MutableDataStructures) {

--- a/core/src/test/scala/wartremover/warts/NoNeedForMonadTest.scala
+++ b/core/src/test/scala/wartremover/warts/NoNeedForMonadTest.scala
@@ -24,7 +24,7 @@ class NoNeedForMonadTest extends FunSuite with ResultAssertions {
       Option(1).flatMap(i => Option(i + 1).map(j => i + j))
     }
 
-    assertWarnings(withWarnings)(NoNeedForMonad.message, 2)
+    assertWarnings(withWarnings)(s"[org.wartremover.warts.NoNeedForMonad] ${NoNeedForMonad.message}", 2)
 
     assertEmpty(noWarnings)
   }
@@ -59,7 +59,7 @@ class NoNeedForMonadTest extends FunSuite with ResultAssertions {
     }
 
 
-    assertWarnings(etaExpanded)(NoNeedForMonad.message, 1)
+    assertWarnings(etaExpanded)(s"[org.wartremover.warts.NoNeedForMonad] ${NoNeedForMonad.message}", 1)
 
     assertEmpty(extendsFunction)
   }

--- a/core/src/test/scala/wartremover/warts/NonUnitStatementsTest.scala
+++ b/core/src/test/scala/wartremover/warts/NonUnitStatementsTest.scala
@@ -11,7 +11,7 @@ class NonUnitStatementsTest extends FunSuite with ResultAssertions {
       1
       2
     }
-    assertError(result)("Statements must return Unit")
+    assertError(result)("[org.wartremover.warts.NonUnitStatements] Statements must return Unit")
   }
   test("Extending a class with multiple parameter lists doesn't fail") {
     val result = WartTestTraverser(NonUnitStatements) {

--- a/core/src/test/scala/wartremover/warts/NothingTest.scala
+++ b/core/src/test/scala/wartremover/warts/NothingTest.scala
@@ -11,7 +11,7 @@ class NothingTest extends FunSuite with ResultAssertions {
       val x = ???
       x
     }
-    assertError(result)("Inferred type containing Nothing")
+    assertError(result)("[org.wartremover.warts.Nothing] Inferred type containing Nothing")
   }
   test("Nothing wart obeys SuppressWarnings") {
     val result = WartTestTraverser(Nothing) {

--- a/core/src/test/scala/wartremover/warts/NullTest.scala
+++ b/core/src/test/scala/wartremover/warts/NullTest.scala
@@ -10,7 +10,7 @@ class NullTest extends FunSuite with ResultAssertions {
     val result = WartTestTraverser(Null) {
       println(null)
     }
-    assertError(result)("null is disabled")
+    assertError(result)("[org.wartremover.warts.Null] null is disabled")
   }
 
   test("reference field placeholder is disabled") {
@@ -19,7 +19,7 @@ class NullTest extends FunSuite with ResultAssertions {
         var s: String = _
       }
     }
-    assertError(result)("null is disabled")
+    assertError(result)("[org.wartremover.warts.Null] null is disabled")
 
     val resultPrimitive = WartTestTraverser(Null) {
       class c {
@@ -35,7 +35,7 @@ class NullTest extends FunSuite with ResultAssertions {
       val (a, b) = (1, null)
       println(a)
     }
-    assertError(result)("null is disabled")
+    assertError(result)("[org.wartremover.warts.Null] null is disabled")
   }
 
   test("can't use null in default arguments") {
@@ -43,21 +43,21 @@ class NullTest extends FunSuite with ResultAssertions {
       class ClassWithArgs(val foo: String = null)
       case class CaseClassWithArgs(val foo: String = null)
     }
-    assertErrors(result)("null is disabled", 2)
+    assertErrors(result)("[org.wartremover.warts.Null] null is disabled", 2)
   }
 
   test("can't use null inside of Map#partition") {
     val result = WartTestTraverser(Null) {
       Map(1 -> "one", 2 -> "two").partition { case (k, v) => null.asInstanceOf[Boolean] }
     }
-    assertError(result)("null is disabled")
+    assertError(result)("[org.wartremover.warts.Null] null is disabled")
   }
 
   test("can't use `Option#orNull`") {
     val result = WartTestTraverser(Null) {
       println(None.orNull)
     }
-    assertError(result)("Option#orNull is disabled")
+    assertError(result)("[org.wartremover.warts.Null] Option#orNull is disabled")
   }
 
   test("Null wart obeys SuppressWarnings") {

--- a/core/src/test/scala/wartremover/warts/Option2IterableTest.scala
+++ b/core/src/test/scala/wartremover/warts/Option2IterableTest.scala
@@ -11,19 +11,19 @@ class Option2IterableTest extends FunSuite with ResultAssertions {
     val result = WartTestTraverser(Option2Iterable) {
       println(Iterable(1).flatMap(Some(_)))
     }
-    assertError(result)("Implicit conversion from Option to Iterable is disabled - use Option#toList instead")
+    assertError(result)("[org.wartremover.warts.Option2Iterable] Implicit conversion from Option to Iterable is disabled - use Option#toList instead")
   }
   test("can't use Option.option2Iterable with None") {
     val result = WartTestTraverser(Option2Iterable) {
       println(Iterable(1).flatMap(_ => None))
     }
-    assertError(result)("Implicit conversion from Option to Iterable is disabled - use Option#toList instead")
+    assertError(result)("[org.wartremover.warts.Option2Iterable] Implicit conversion from Option to Iterable is disabled - use Option#toList instead")
   }
   test("can't use Option.option2Iterable when zipping Options") {
     val result = WartTestTraverser(Option2Iterable) {
       println(Option(1) zip Option(2))
     }
-    assertErrors(result)("Implicit conversion from Option to Iterable is disabled - use Option#toList instead", 2)
+    assertErrors(result)("[org.wartremover.warts.Option2Iterable] Implicit conversion from Option to Iterable is disabled - use Option#toList instead", 2)
   }
   test("doesn't detect user defined option2Iterable functions") {
     def option2Iterable[A](o: Option[A]): Iterable[A] = o.toIterable

--- a/core/src/test/scala/wartremover/warts/OptionPartialTest.scala
+++ b/core/src/test/scala/wartremover/warts/OptionPartialTest.scala
@@ -10,13 +10,13 @@ class OptionPartialTest extends FunSuite with ResultAssertions {
     val result = WartTestTraverser(OptionPartial) {
       println(Some(1).get)
     }
-    assertError(result)("Option#get is disabled - use Option#fold instead")
+    assertError(result)("[org.wartremover.warts.OptionPartial] Option#get is disabled - use Option#fold instead")
   }
   test("can't use Option#get on None") {
     val result = WartTestTraverser(OptionPartial) {
       println(None.get)
     }
-    assertError(result)("Option#get is disabled - use Option#fold instead")
+    assertError(result)("[org.wartremover.warts.OptionPartial] Option#get is disabled - use Option#fold instead")
   }
   test("doesn't detect other `get` methods") {
     val result = WartTestTraverser(OptionPartial) {

--- a/core/src/test/scala/wartremover/warts/OverloadingTest.scala
+++ b/core/src/test/scala/wartremover/warts/OverloadingTest.scala
@@ -14,7 +14,7 @@ class OverloadingTest extends FunSuite with ResultAssertions {
         def wait(s: String) = {}
       }
     }
-    assertErrors(result)("Overloading is disabled", 3)
+    assertErrors(result)("[org.wartremover.warts.Overloading] Overloading is disabled", 3)
   }
 
   test("Overloading wart obeys SuppressWarnings") {

--- a/core/src/test/scala/wartremover/warts/ProductTest.scala
+++ b/core/src/test/scala/wartremover/warts/ProductTest.scala
@@ -10,7 +10,7 @@ class ProductTest extends FunSuite with ResultAssertions {
     val result = WartTestTraverser(Product) {
       List((1, 2, 3), (1, 2))
     }
-    assertError(result)("Inferred type containing Product")
+    assertError(result)("[org.wartremover.warts.Product] Inferred type containing Product")
   }
   test("Product wart obeys SuppressWarnings") {
     val result = WartTestTraverser(Product) {

--- a/core/src/test/scala/wartremover/warts/PublicInferenceTest.scala
+++ b/core/src/test/scala/wartremover/warts/PublicInferenceTest.scala
@@ -12,7 +12,7 @@ class PublicInferenceTest extends FunSuite with ResultAssertions {
         def f() = ()
       }
     }
-    assertErrors(result)("Public member must have an explicit type ascription", 2)
+    assertErrors(result)("[org.wartremover.warts.PublicInference] Public member must have an explicit type ascription", 2)
   }
 
   test("Public members with explicit types are enabled") {

--- a/core/src/test/scala/wartremover/warts/ReturnTest.scala
+++ b/core/src/test/scala/wartremover/warts/ReturnTest.scala
@@ -10,13 +10,13 @@ class ReturnTest extends FunSuite with ResultAssertions {
     val result = WartTestTraverser(Return) {
       def foo(n:Int): Int = return n + 1
     }
-    assertError(result)("return is disabled")
+    assertError(result)("[org.wartremover.warts.Return] return is disabled")
   }
   test("nonlocal return is disabled") {
     val result = WartTestTraverser(Return) {
       def foo(ns: List[Int]): Any = ns.map(n => return n + 1)
     }
-    assertError(result)("return is disabled")
+    assertError(result)("[org.wartremover.warts.Return] return is disabled")
   }
   test("Return wart is disabled") {
     val result = WartTestTraverser(Return) {

--- a/core/src/test/scala/wartremover/warts/SerializableTest.scala
+++ b/core/src/test/scala/wartremover/warts/SerializableTest.scala
@@ -10,7 +10,7 @@ class SerializableTest extends FunSuite with ResultAssertions {
     val result = WartTestTraverser(Serializable) {
       List((1, 2, 3), (1, 2))
     }
-    assertError(result)("Inferred type containing Serializable")
+    assertError(result)("[org.wartremover.warts.Serializable] Inferred type containing Serializable")
   }
   test("Serializable wart obeys SuppressWarnings") {
     val result = WartTestTraverser(Serializable) {

--- a/core/src/test/scala/wartremover/warts/StringPlusAnyTest.scala
+++ b/core/src/test/scala/wartremover/warts/StringPlusAnyTest.scala
@@ -12,14 +12,14 @@ class StringPlusAnyTest extends FunSuite with ResultAssertions {
       "lol" + 1
       "" + (if (true) 5 else "")
     }
-    assertErrors(result)("Implicit conversion to string is disabled", 3)
+    assertErrors(result)("[org.wartremover.warts.StringPlusAny] Implicit conversion to string is disabled", 3)
   }
 
   test("Primitive conversion to string is disabled") {
     val result = WartTestTraverser(StringPlusAny) {
       1 + "lol"
     }
-    assertError(result)("Implicit conversion to string is disabled")
+    assertError(result)("[org.wartremover.warts.StringPlusAny] Implicit conversion to string is disabled")
   }
 
   test("Non-string + usage is allowed") {

--- a/core/src/test/scala/wartremover/warts/ThrowTest.scala
+++ b/core/src/test/scala/wartremover/warts/ThrowTest.scala
@@ -10,14 +10,14 @@ class ThrowTest extends FunSuite with ResultAssertions {
     val result = WartTestTraverser(Throw) {
       def foo(n: Int): Int = throw new IllegalArgumentException("bar")
     }
-    assertError(result)("throw is disabled")
+    assertError(result)("[org.wartremover.warts.Throw] throw is disabled")
   }
 
   test("throw is disabled for non-synthetic MatchErrors") {
     val result = WartTestTraverser(Throw) {
       def foo(n: Int): Int = throw new MatchError("bar")
     }
-    assertError(result)("throw is disabled")
+    assertError(result)("[org.wartremover.warts.Throw] throw is disabled")
   }
 
   test("throw is allowed in synthetic Product.productElement") {

--- a/core/src/test/scala/wartremover/warts/ToStringTest.scala
+++ b/core/src/test/scala/wartremover/warts/ToStringTest.scala
@@ -12,27 +12,27 @@ class ToStringTest extends FunSuite with ResultAssertions {
       val foo: Foo = new Foo(5)
 		foo.toString
     }
-    assertError(result)("class Foo does not override toString and automatic toString is disabled")
+    assertError(result)("[org.wartremover.warts.ToString] class Foo does not override toString and automatic toString is disabled")
   }
   test("can't use automatic toString method of TypeRefs") {
     val result = WartTestTraverser(ToString) {
       def foo[A](a: A): String = a.toString
     }
-    assertError(result)("class Any does not override toString and automatic toString is disabled")
+    assertError(result)("[org.wartremover.warts.ToString] class Any does not override toString and automatic toString is disabled")
   }
   test("can't use generated toString method of case classes") {
     val result = WartTestTraverser(ToString) {
       case class Foo(i: Int)
 		Foo(5).toString
     }
-    assertError(result)("class Foo does not override toString and automatic toString is disabled")
+    assertError(result)("[org.wartremover.warts.ToString] class Foo does not override toString and automatic toString is disabled")
   }
   test("can't use generated toString method of case objects") {
     val result = WartTestTraverser(ToString) {
       case object Foo
 		Foo.toString
     }
-    assertError(result)("object Foo does not override toString and automatic toString is disabled")
+    assertError(result)("[org.wartremover.warts.ToString] object Foo does not override toString and automatic toString is disabled")
   }
   test("can use overridden toString method") {
     val result = WartTestTraverser(ToString) {

--- a/core/src/test/scala/wartremover/warts/TraversableOpsTest.scala
+++ b/core/src/test/scala/wartremover/warts/TraversableOpsTest.scala
@@ -10,49 +10,49 @@ class TraversableOpsTest extends FunSuite with ResultAssertions {
       val result = WartTestTraverser(TraversableOps) {
         println(x.head)
       }
-      assertError(result)("head is disabled - use headOption instead")
+      assertError(result)("[org.wartremover.warts.TraversableOps] head is disabled - use headOption instead")
     }
 
     test(s"can't use $name#tail") {
       val result = WartTestTraverser(TraversableOps) {
         println(x.tail)
       }
-      assertError(result)("tail is disabled - use drop(1) instead")
+      assertError(result)("[org.wartremover.warts.TraversableOps] tail is disabled - use drop(1) instead")
     }
 
     test(s"can't use $name#init") {
       val result = WartTestTraverser(TraversableOps) {
         println(x.init)
       }
-      assertError(result)("init is disabled - use dropRight(1) instead")
+      assertError(result)("[org.wartremover.warts.TraversableOps] init is disabled - use dropRight(1) instead")
     }
 
     test(s"can't use $name#last") {
       val result = WartTestTraverser(TraversableOps) {
         println(x.last)
       }
-      assertError(result)("last is disabled - use lastOption instead")
+      assertError(result)("[org.wartremover.warts.TraversableOps] last is disabled - use lastOption instead")
     }
 
     test(s"can't use $name#reduce") {
       val result = WartTestTraverser(TraversableOps) {
         println(x.reduce(_.hashCode + _.hashCode))
       }
-      assertError(result)("reduce is disabled - use reduceOption or fold instead")
+      assertError(result)("[org.wartremover.warts.TraversableOps] reduce is disabled - use reduceOption or fold instead")
     }
 
     test(s"can't use $name#reduceLeft") {
       val result = WartTestTraverser(TraversableOps) {
         println(x.reduceLeft(_.hashCode + _.hashCode))
       }
-      assertError(result)("reduceLeft is disabled - use reduceLeftOption or foldLeft instead")
+      assertError(result)("[org.wartremover.warts.TraversableOps] reduceLeft is disabled - use reduceLeftOption or foldLeft instead")
     }
 
     test(s"can't use $name#reduceRight") {
       val result = WartTestTraverser(TraversableOps) {
         println(x.reduceRight(_.hashCode + _.hashCode))
       }
-      assertError(result)("reduceRight is disabled - use reduceRightOption or foldRight instead")
+      assertError(result)("[org.wartremover.warts.TraversableOps] reduceRight is disabled - use reduceRightOption or foldRight instead")
     }
   }
 

--- a/core/src/test/scala/wartremover/warts/TryPartialTest.scala
+++ b/core/src/test/scala/wartremover/warts/TryPartialTest.scala
@@ -10,13 +10,13 @@ class TryPartialTest extends FunSuite with ResultAssertions {
     val result = WartTestTraverser(TryPartial) {
       println(Success(1).get)
     }
-    assertError(result)("Try#get is disabled")
+    assertError(result)("[org.wartremover.warts.TryPartial] Try#get is disabled")
   }
   test("can't use Try#get on Failure") {
     val result = WartTestTraverser(TryPartial) {
       println(Failure(new Error).get)
     }
-    assertError(result)("Try#get is disabled")
+    assertError(result)("[org.wartremover.warts.TryPartial] Try#get is disabled")
   }
   test("doesn't detect other `get` methods") {
     val result = WartTestTraverser(TryPartial) {

--- a/core/src/test/scala/wartremover/warts/UnsafeTest.scala
+++ b/core/src/test/scala/wartremover/warts/UnsafeTest.scala
@@ -18,17 +18,17 @@ class UnsafeTest extends FunSuite {
       println(null)
     }
     assertResult(
-      Set("Inferred type containing Any",
-           "Inferred type containing Any",
-           "Scala inserted an any2stringadd call",
-           "LeftProjection#get is disabled - use LeftProjection#toOption instead",
-           "RightProjection#get is disabled - use RightProjection#toOption instead",
-           "LeftProjection#get is disabled - use LeftProjection#toOption instead",
-           "RightProjection#get is disabled - use RightProjection#toOption instead",
-           "Statements must return Unit",
-           "null is disabled",
-           "Option#get is disabled - use Option#fold instead",
-           "var is disabled"), "result.errors")(result.errors.toSet)
+      Set("[org.wartremover.warts.Unsafe] Inferred type containing Any",
+           "[org.wartremover.warts.Unsafe] Inferred type containing Any",
+           "[org.wartremover.warts.Unsafe] Scala inserted an any2stringadd call",
+           "[org.wartremover.warts.Unsafe] LeftProjection#get is disabled - use LeftProjection#toOption instead",
+           "[org.wartremover.warts.Unsafe] RightProjection#get is disabled - use RightProjection#toOption instead",
+           "[org.wartremover.warts.Unsafe] LeftProjection#get is disabled - use LeftProjection#toOption instead",
+           "[org.wartremover.warts.Unsafe] RightProjection#get is disabled - use RightProjection#toOption instead",
+           "[org.wartremover.warts.Unsafe] Statements must return Unit",
+           "[org.wartremover.warts.Unsafe] null is disabled",
+           "[org.wartremover.warts.Unsafe] Option#get is disabled - use Option#fold instead",
+           "[org.wartremover.warts.Unsafe] var is disabled"), "result.errors")(result.errors.toSet)
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
 }

--- a/core/src/test/scala/wartremover/warts/VarTest.scala
+++ b/core/src/test/scala/wartremover/warts/VarTest.scala
@@ -11,7 +11,7 @@ class VarTest extends FunSuite with ResultAssertions {
       var x = 10
       x
     }
-    assertError(result)("var is disabled")
+    assertError(result)("[org.wartremover.warts.Var] var is disabled")
   }
   test("Var wart obeys SuppressWarnings") {
     val result = WartTestTraverser(Var) {

--- a/core/src/test/scala/wartremover/warts/WhileTest.scala
+++ b/core/src/test/scala/wartremover/warts/WhileTest.scala
@@ -12,7 +12,7 @@ class WhileTest extends FunSuite with ResultAssertions {
         println()
       }
     }
-    assertError(result)("while is disabled")
+    assertError(result)("[org.wartremover.warts.While] while is disabled")
   }
 
   test("do while is disabled") {
@@ -21,7 +21,7 @@ class WhileTest extends FunSuite with ResultAssertions {
         println()
       } while (true)
     }
-    assertError(result)("while is disabled")
+    assertError(result)("[org.wartremover.warts.While] while is disabled")
   }
 
   test("while wart obeys SuppressWarnings") {


### PR DESCRIPTION
Previously #319 . Discussed in #318 .

Automatically appends [className] in front of error/warning messages.

Eg.
Statements must return Unit
now appears as:
[org.wartremover.warts.NonUnitStatements] Statements must return Unit