### PR TITLE
Scope should not be Global.

### DIFF
--- a/sbt-plugin/src/main/scala/wartremover/package.scala
+++ b/sbt-plugin/src/main/scala/wartremover/package.scala
@@ -16,7 +16,7 @@ package object wartremover {
 
     resolvers += Resolver.sonatypeRepo("releases"),
     addCompilerPlugin("org.wartremover" %% "wartremover" % Wart.PluginVersion)
-  ) ++ inScope(Global)(Seq(
+  ) ++ inScope(This)(Seq(
     derive(scalacOptions ++= wartremoverErrors.value.distinct map (w => s"-P:wartremover:traverser:${w.clazz}")),
     derive(scalacOptions ++= wartremoverWarnings.value.distinct filterNot (wartremoverErrors.value contains _) map (w => s"-P:wartremover:only-warn-traverser:${w.clazz}")),
     derive(scalacOptions ++= wartremoverExcluded.value.distinct map (c => s"-P:wartremover:excluded:${c.getAbsolutePath}")),


### PR DESCRIPTION
Scope should not be Global. This results in Wart Remover keys such as 'wartremoverClasspaths' growing for each sub-module in a multi-module project. This also can create situations where the CLASSPATH is fubar and dependencies can no longer be found