### PR TITLE
do not mutate the user's resolvers

### DIFF
--- a/sbt-plugin/src/main/scala/wartremover/package.scala
+++ b/sbt-plugin/src/main/scala/wartremover/package.scala
@@ -14,7 +14,6 @@ package object wartremover {
     wartremoverExcluded := Seq.empty,
     wartremoverClasspaths := Seq.empty,
 
-    resolvers += Resolver.sonatypeRepo("releases"),
     addCompilerPlugin("org.wartremover" %% "wartremover" % Wart.PluginVersion)
   ) ++ inScope(Global)(Seq(
     derive(scalacOptions ++= wartremoverErrors.value.distinct map (w => s"-P:wartremover:traverser:${w.clazz}")),


### PR DESCRIPTION
this removes a change that mutates the user's repository settings. This may be something that could be added to the installation instructions.