### PR TITLE
Ready to publish for sbt 1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -94,6 +94,7 @@ lazy val sbtPlug: Project = Project(
 ).settings(commonSettings ++ Seq(
   sbtPlugin := true,
   name := "sbt-wartremover",
+  crossSbtVersions := Vector("0.13.15", "1.0.0-M5"),
   sourceGenerators in Compile <+= Def.task {
     val base = (sourceManaged in Compile).value
     val file = base / "wartremover" / "Wart.scala"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.16-M1


### PR DESCRIPTION
- Update build to sbt `0.13.16-M1` which provides built-in cross-publishing functionality
- Set cross-publishing versions

One can cross-publish the sbt plugin by using the `^publish` command in the `sbt-plugin` sub-project