### PR TITLE
Make IsInstanceOf ignore macro expansions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -87,7 +87,7 @@ lazy val core = Project(
   // a hack (?) to make `compile` and `+compile` tasks etc. behave sanely
   aggregate := CrossVersion.partialVersion((scalaVersion in Global).value) == Some((2, 10)),
   assemblyOutputPath in assembly := file("./wartremover-assembly.jar")
-): _*)
+): _*).dependsOn(testMacros % "test->compile")
 
 lazy val sbtPlug: Project = Project(
   id = "sbt-plugin",
@@ -120,3 +120,15 @@ lazy val sbtPlug: Project = Project(
     Seq(file)
   }
 ): _*)
+
+lazy val testMacros: Project = Project(
+  id = "test-macros",
+  base = file("test-macros")
+).settings(
+  libraryDependencies ++= Seq(
+    "org.typelevel" %% "macro-compat" % "1.1.1",
+    "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided",
+    compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.patch)
+  ),
+  scalaVersion := (crossScalaVersions in ThisBuild).value.head
+)

--- a/core/src/main/scala/wartremover/warts/IsInstanceOf.scala
+++ b/core/src/main/scala/wartremover/warts/IsInstanceOf.scala
@@ -19,7 +19,8 @@ object IsInstanceOf extends WartTraverser {
           case DefDef(_, CanEqualName | EqualsName, _, _, _, _) if synthetic => 
 
           // Otherwise nope, for non-synthetic receivers
-          case Select(id, IsInstanceOfName) if !isSynthetic(u)(id) =>
+          case Select(id, IsInstanceOfName) if !isSynthetic(u)(id)
+              && tree.pos.lineContent.contains(IsInstanceOfName.toString) =>
             error(u)(tree.pos, "isInstanceOf is disabled")
 
           case _ => super.traverse(tree)

--- a/core/src/test/scala/wartremover/warts/IsInstanceOfTest.scala
+++ b/core/src/test/scala/wartremover/warts/IsInstanceOfTest.scala
@@ -19,4 +19,10 @@ class IsInstanceOfTest extends FunSuite with ResultAssertions {
     }
     assertEmpty(result)
   }
+  test("isInstanceOf should not check macro expansions") {
+    val result = WartTestTraverser(IsInstanceOf) {
+      IsInstanceOfTestMacros.is[Object, String]
+    }
+    assertEmpty(result)
+  }
 }

--- a/test-macros/src/main/scala/wartremover/test/IsInstanceOfTestMacros.scala
+++ b/test-macros/src/main/scala/wartremover/test/IsInstanceOfTestMacros.scala
@@ -1,0 +1,24 @@
+package org.wartremover
+package test
+
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox
+
+object IsInstanceOfTestMacros {
+
+  def is[A, B]: A => Boolean = macro IsInstanceOfTestMacrosImpl.is_impl[A, B]
+}
+
+@macrocompat.bundle
+private class IsInstanceOfTestMacrosImpl(val c: blackbox.Context) {
+  def is_impl[A: c.WeakTypeTag, B: c.WeakTypeTag]: c.Expr[A => Boolean] = {
+    import c.universe._
+
+    val aTpe = weakTypeOf[A]
+    val bTpe = weakTypeOf[B]
+
+    c.Expr[A => Boolean](q"""
+      (a: $aTpe) => a.isInstanceOf[$bTpe]
+    """)
+  }
+}


### PR DESCRIPTION
Closes #369 

This uses the trick from `AsInstanceOf` to detect macro expansions.