### PR TITLE
Add wart to avoid inference of java.io.Serializable

### DIFF
--- a/core/src/main/scala/wartremover/warts/JavaSerializable.scala
+++ b/core/src/main/scala/wartremover/warts/JavaSerializable.scala
@@ -1,0 +1,6 @@
+package org.wartremover
+package warts
+
+object JavaSerializable extends ForbidInference[java.io.Serializable] {
+  def apply(u: WartUniverse): u.Traverser = applyForbidden(u)
+}

--- a/core/src/test/scala/wartremover/warts/JavaSerializableTest.scala
+++ b/core/src/test/scala/wartremover/warts/JavaSerializableTest.scala
@@ -1,0 +1,28 @@
+package org.wartremover
+package test
+
+import java.io.Serializable
+import org.scalatest.FunSuite
+import org.wartremover.warts.JavaSerializable
+
+
+object Foo extends Serializable
+
+class JavaSerializableTest extends FunSuite with ResultAssertions {
+  test("java.io.Serializable can't be inferred") {
+    val result = WartTestTraverser(JavaSerializable) {
+      // String is not a subtype of scala.Serializable, but is of java.io.Serializable
+      // Foo is a subtype of scala.Serializable, which is a subtype of java.io.Serializable
+      // so scala should infer List[java.io.Serializable]
+      List("foo", Foo)
+    }
+    assertError(result)("Inferred type containing Serializable")
+  }
+  test("Serializable wart obeys SuppressWarnings") {
+    val result = WartTestTraverser(JavaSerializable) {
+      @SuppressWarnings(Array("org.wartremover.warts.JavaSerializable"))
+      val foo = List("foo", Foo)
+    }
+    assertEmpty(result)
+  }
+}

--- a/docs/_posts/2017-02-11-warts.md.dev
+++ b/docs/_posts/2017-02-11-warts.md.dev
@@ -141,6 +141,20 @@ val scalaMap: Map[String, String] = Map()
 val javaMap: java.util.Map[String, String] = scalaMap
 ```
 
+### JavaSerializable
+
+`java.io.Serializable` is a common subtype to many structures, especially those
+imported from Java.  For example, String is a subtype of java.io.Serializable
+but not `scala.Serializable`.  The Scala compiler loves to infer
+`java.io.Serializable` as a common supertype, but that is almost always
+incorrect. Explicit type arguments should be used instead.
+
+```scala
+// Won't compile: Inferred type containing java.io.Serializable
+object O extends Serializable
+val mistake = List("foo", "bar", O /* forgot O.toString */)
+```
+
 ### LeakingSealed
 
 Descendants of a sealed type must be final or sealed. Otherwise this type can be extended in another file through its descendant.


### PR DESCRIPTION
I just hit a nasty bug where I had, essentially,

    sealed trait T extends Product with Serializable
    case object O extends T
    val mistake = List("foo", "bar", O /* forgot O.toString */)

So scala went ahead and inferred List[java.io.Serializable] for this list, since
String is not scala.Serializable, but is java.io.Serializable, and T is
scala.Serializable which extends java.io.Serializable. I typically rely on
WartRemover to catch such mistakes, but in this case it didn't.