### PR TITLE
Docs: Typo "aas"

### DIFF
--- a/docs/_posts/2017-02-11-warts.md
+++ b/docs/_posts/2017-02-11-warts.md
@@ -110,7 +110,7 @@ implicit def int2Array(i: Int) = Array.fill(i)("madness")
 
 ### ImplicitParameter
 
-Implicit parameters aas configuration often lead to confusing interfaces and can result in surprising inconsistencies.
+Implicit parameters as configuration often lead to confusing interfaces and can result in surprising inconsistencies.
 
 ```scala
 // Won't compile: Implicit parameters are disabled

--- a/docs/_posts/2017-02-11-warts.md.dev
+++ b/docs/_posts/2017-02-11-warts.md.dev
@@ -119,7 +119,7 @@ implicit def int2Array(i: Int) = Array.fill(i)("madness")
 
 ### ImplicitParameter
 
-Implicit parameters aas configuration often lead to confusing interfaces and can result in surprising inconsistencies.
+Implicit parameters as configuration often lead to confusing interfaces and can result in surprising inconsistencies.
 
 ```scala
 // Won't compile: Implicit parameters are disabled


### PR DESCRIPTION
Not 100 % sure, but "aas" is meant to be "as", right? ;)