### PR TITLE
Cross-build for SBT 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 sudo: false
 language: scala
-jdk: oraclejdk7
 scala:
-  - 2.11.8
   - 2.10.6
+  - 2.11.11
+  - 2.12.3
+jdk:
+  - oraclejdk7
+  - oraclejdk8
 matrix:
-  include:
-    - scala: 2.12.0
-      jdk: oraclejdk8
+  exclude:
+    - scala: 2.12.3
+      jdk: oraclejdk7
+script: sbt "+++$TRAVIS_SCALA_VERSION compile" "+++$TRAVIS_SCALA_VERSION test"

--- a/project/TravisYaml.scala
+++ b/project/TravisYaml.scala
@@ -1,0 +1,30 @@
+package org.wartremover
+
+import java.util.{Map => JMap, List => JList}
+import org.yaml.snakeyaml.Yaml
+import sbt.{AutoPlugin, Setting, SettingKey, Using}
+import sbt.Def.settingKey
+import sbt.Keys.baseDirectory
+import sbt.Path.richFile
+import scala.collection.JavaConverters._
+
+// Adapted from dwijnand/sbt-travisci
+
+object TravisYaml extends AutoPlugin {
+  lazy val travisScalaVersions: SettingKey[Seq[String]] = settingKey("Retrieves scala versions from .travis.yml")
+
+  lazy val travisScalaVersionsSetting: Setting[Seq[String]] =
+    travisScalaVersions :=
+      Using.fileInputStream(baseDirectory.value / ".travis.yml") { fis =>
+        Option((new Yaml).load(fis))
+          .collect { case map: JMap[_, _] => map }
+          .flatMap(map => Option(map get "scala"))
+          .collect {
+            case versions: JList[_] => versions.asScala.toList map (_.toString)
+            case version: String    => version :: Nil
+          }
+          .getOrElse(Nil)
+      }
+
+  override lazy val buildSettings: Seq[Setting[_]] = Seq(travisScalaVersionsSetting)
+}

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,0 +1,1 @@
+libraryDependencies += "org.yaml" % "snakeyaml" % "1.18"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,8 +2,8 @@ resolvers += Resolver.sonatypeRepo("releases")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
 
+addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")
+
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
-
-addSbtPlugin("com.dwijnand" % "sbt-travisci" % "1.1.1")


### PR DESCRIPTION
Closes #393 

- sbt-doge is added due to requiring different crossScalaVersions for core and sbt-plugin
- sbt-travisci is removed due to getting in the way of sbt-doge
- Scala versions are still retrieved from .travis.yml via a new plugin adapted from sbt-travisci

Perhaps this is sufficient to get wartremover cross-publishing to SBT 1.0.
