### PR TITLE
Default all wartremover sbt keys in global scope

### DIFF
--- a/sbt-plugin/src/main/scala/wartremover/WartRemover.scala
+++ b/sbt-plugin/src/main/scala/wartremover/WartRemover.scala
@@ -13,5 +13,13 @@ object WartRemover extends sbt.AutoPlugin {
     val Wart = wartremover.Wart
     val Warts = wartremover.Warts
   }
+
+  override def globalSettings = Seq(
+    wartremoverErrors := Nil,
+    wartremoverWarnings := Nil,
+    wartremoverExcluded := Nil,
+    wartremoverClasspaths := Nil
+  )
+
   override lazy val projectSettings = wartremoverSettings
 }

--- a/sbt-plugin/src/main/scala/wartremover/package.scala
+++ b/sbt-plugin/src/main/scala/wartremover/package.scala
@@ -9,11 +9,6 @@ package object wartremover {
   val wartremoverClasspaths = taskKey[Seq[String]]("List of classpaths for custom Warts")
 
   lazy val wartremoverSettings: Seq[sbt.Def.Setting[_]] = Seq(
-    wartremoverErrors := Seq.empty,
-    wartremoverWarnings := Seq.empty,
-    wartremoverExcluded := Seq.empty,
-    wartremoverClasspaths := Seq.empty,
-
     addCompilerPlugin("org.wartremover" %% "wartremover" % Wart.PluginVersion)
   ) ++ inScope(Scope.ThisScope)(Seq(
     derive(scalacOptions ++= wartremoverErrors.value.distinct map (w => s"-P:wartremover:traverser:${w.clazz}")),


### PR DESCRIPTION
As recommended by the Plugins Best Practices:
http://www.scala-sbt.org/1.x/docs/Plugins.html#projectSettings+and+buildSettings

Fixes #283