### PR TITLE
Include max/min methods into TraversableOps wart

### DIFF
--- a/core/src/main/scala/wartremover/warts/TraversableOps.scala
+++ b/core/src/main/scala/wartremover/warts/TraversableOps.scala
@@ -36,7 +36,11 @@ object TraversableOps extends WartTraverser {
       new Op("last", "last is disabled - use lastOption instead"),
       new Op("reduce", "reduce is disabled - use reduceOption or fold instead"),
       new Op("reduceLeft", "reduceLeft is disabled - use reduceLeftOption or foldLeft instead"),
-      new Op("reduceRight", "reduceRight is disabled - use reduceRightOption or foldRight instead")
+      new Op("reduceRight", "reduceRight is disabled - use reduceRightOption or foldRight instead"),
+      new Op("maxBy", "maxBy is disabled - use foldLeft or foldRight instead"),
+      new Op("max", "max is disabled - use foldLeft or foldRight instead"),
+      new Op("minBy", "minBy is disabled - use foldLeft or foldRight instead"),
+      new Op("min", "min is disabled - use foldLeft or foldRight instead")
     ))
 
 }

--- a/core/src/test/scala/wartremover/warts/TraversableOpsTest.scala
+++ b/core/src/test/scala/wartremover/warts/TraversableOpsTest.scala
@@ -5,6 +5,10 @@ import org.scalatest.FunSuite
 import org.wartremover.warts.TraversableOps
 
 class TraversableOpsTest extends FunSuite with ResultAssertions {
+
+
+  implicit val ordering: Ordering[Any] = (x: Any, y: Any) => 0
+
   Seq[(String, Traversable[Any])]("List" -> List(1), "Seq" -> Seq(1), "Map" -> Map(1 -> 1)).foreach { case (name, x) =>
     test(s"can't use $name#head") {
       val result = WartTestTraverser(TraversableOps) {
@@ -54,6 +58,34 @@ class TraversableOpsTest extends FunSuite with ResultAssertions {
       }
       assertError(result)("reduceRight is disabled - use reduceRightOption or foldRight instead")
     }
+
+    test(s"can't use $name#max") {
+      val result = WartTestTraverser(TraversableOps) {
+        println(x.max)
+      }
+      assertError(result)("max is disabled - use foldLeft or foldRight instead")
+    }
+
+    test(s"can't use $name#maxBy") {
+      val result = WartTestTraverser(TraversableOps) {
+        println(x.maxBy(_.hashCode))
+      }
+      assertError(result)("maxBy is disabled - use foldLeft or foldRight instead")
+    }
+
+    test(s"can't use $name#min") {
+      val result = WartTestTraverser(TraversableOps) {
+        println(x.min)
+      }
+      assertError(result)("min is disabled - use foldLeft or foldRight instead")
+    }
+
+    test(s"can't use $name#minBy") {
+      val result = WartTestTraverser(TraversableOps) {
+        println(x.minBy(_.hashCode))
+      }
+      assertError(result)("minBy is disabled - use foldLeft or foldRight instead")
+    }
   }
 
   test("TraversableOps wart obeys SuppressWarnings") {
@@ -67,6 +99,10 @@ class TraversableOpsTest extends FunSuite with ResultAssertions {
         println(List.empty[Int].reduce(_ + _))
         println(List.empty[Int].reduceLeft(_ + _))
         println(List.empty[Int].reduceRight(_ + _))
+        println(List.empty[Int].max)
+        println(List.empty[Int].maxBy(identity))
+        println(List.empty[Int].min)
+        println(List.empty[Int].minBy(identity))
       }
     }
     assertEmpty(result)

--- a/core/src/test/scala/wartremover/warts/TraversableOpsTest.scala
+++ b/core/src/test/scala/wartremover/warts/TraversableOpsTest.scala
@@ -7,7 +7,9 @@ import org.wartremover.warts.TraversableOps
 class TraversableOpsTest extends FunSuite with ResultAssertions {
 
 
-  implicit val ordering: Ordering[Any] = (x: Any, y: Any) => 0
+  implicit val ordering: Ordering[Any] = new Ordering[Any] {
+    override def compare(x: Any, y: Any) = 0
+  }
 
   Seq[(String, Traversable[Any])]("List" -> List(1), "Seq" -> Seq(1), "Map" -> Map(1 -> 1)).foreach { case (name, x) =>
     test(s"can't use $name#head") {

--- a/docs/_posts/2017-02-11-warts.md.dev
+++ b/docs/_posts/2017-02-11-warts.md.dev
@@ -337,8 +337,12 @@ case object Foo { override val toString = "Foo" }
 * `init`,
 * `last`,
 * `reduce`,
-* `reduceLeft` and
-* `reduceRight` methods,
+* `reduceLeft`,
+* `reduceRight`,
+* `max`,
+* `maxBy`,
+* `min` and
+* `minBy` methods,
 
 all of which will throw if the collection is empty. The program should be refactored to use:
 


### PR DESCRIPTION
Hi,

This PR supposed to extend the `TraversableOps` cases coverage including into checks the dependent methods of `TraversableOnce[+A]` related to `Ordering`:

* `min`
* `minBy`
* `max`
* `maxBy`

Due to `TraversableOps` already covers all `reduce` methods it feels natural to cover the ones which use `reduces` undercover as well as goes with explicit check like:
```scala
if (isEmpty)
      throw new UnsupportedOperationException("empty.max")
```