### PR TITLE
Exclude on path prefix to enable excluding directories

### DIFF
--- a/core/src/main/scala/wartremover/Plugin.scala
+++ b/core/src/main/scala/wartremover/Plugin.scala
@@ -59,7 +59,7 @@ class Plugin(val global: Global) extends tools.nsc.plugins.Plugin {
 
     override def newPhase(prev: Phase) = new StdPhase(prev) {
       override def apply(unit: CompilationUnit) = {
-        val isExcluded = excludedFiles contains unit.source.file.absolute.path
+        val isExcluded = excludedFiles exists unit.source.file.absolute.path.startsWith
 
         if (!isExcluded) {
           def wartUniverse(onlyWarn: Boolean) = new WartUniverse {

--- a/docs/_posts/2017-02-11-install-setup.md
+++ b/docs/_posts/2017-02-11-install-setup.md
@@ -57,10 +57,11 @@ To exclude a specific piece of code from one or more checks, use the `SuppressWa
 var foo = null
 ```
 
-To exclude a file from all checks, use `wartremoverExcluded` in your `build.sbt` file:
+To exclude a file or directory from all checks, use `wartremoverExcluded` in your `build.sbt` file:
 
 ```scala
 wartremoverExcluded += baseDirectory.value / "src" / "main" / "scala" / "SomeFile.scala"
+wartremoverExcluded += sourceManaged.value
 ```
 
 ## Other ways of using WartRemover


### PR DESCRIPTION
This change will exclude paths based on path prefix, so it becomes possible to exclude directories.

I chose to exclude the "src_managed" folder by default, as this usually contains automatically generated code (e.g. Thrift, Protocol Buffers) that does not need to be checked by Wartremover.

This will resolve #248 