### PR TITLE
Improve message about inference warts

### DIFF
--- a/core/src/main/scala/wartremover/warts/ForbidInference.scala
+++ b/core/src/main/scala/wartremover/warts/ForbidInference.scala
@@ -22,7 +22,7 @@ trait ForbidInference[T] extends WartTraverser {
     new u.Traverser {
       override def traverse(tree: Tree): Unit = {
         val synthetic = isSynthetic(u)(tree)
-        def error() = ForbidInference.this.error(u)(tree.pos, s"Inferred type containing ${tSymbol.name}")
+        def error(tpe: Type) = ForbidInference.this.error(u)(tree.pos, s"Inferred type containing ${tSymbol.name}: $tpe")
 
         tree match {
           // Ignore trees marked by SuppressWarnings
@@ -33,7 +33,7 @@ trait ForbidInference[T] extends WartTraverser {
               case ExistentialType(_, _) =>
 
               case _ =>
-                error()
+                error(tpt.tpe)
             }
 
           // Ignore case classes generated methods

--- a/core/src/test/scala/wartremover/warts/AnyTest.scala
+++ b/core/src/test/scala/wartremover/warts/AnyTest.scala
@@ -11,8 +11,9 @@ class AnyTest extends FunSuite with ResultAssertions {
       val x = readf1("{0}")
       x
     }
-    assertError(result)("Inferred type containing Any")
+    assertError(result)("Inferred type containing Any: Any")
   }
+
   test("Any wart obeys SuppressWarnings") {
     val result = WartTestTraverser(Any) {
       @SuppressWarnings(Array("org.wartremover.warts.Any"))

--- a/core/src/test/scala/wartremover/warts/AnyValTest.scala
+++ b/core/src/test/scala/wartremover/warts/AnyValTest.scala
@@ -10,7 +10,7 @@ class AnyValTest extends FunSuite with ResultAssertions {
     val result = WartTestTraverser(AnyVal) {
       List(1, true)
     }
-    assertError(result)("Inferred type containing AnyVal")
+    assertError(result)("Inferred type containing AnyVal: AnyVal")
   }
 
   test("AnyVal wart obeys SuppressWarnings") {

--- a/core/src/test/scala/wartremover/warts/JavaSerializableTest.scala
+++ b/core/src/test/scala/wartremover/warts/JavaSerializableTest.scala
@@ -16,8 +16,9 @@ class JavaSerializableTest extends FunSuite with ResultAssertions {
       // so scala should infer List[java.io.Serializable]
       List("foo", Foo)
     }
-    assertError(result)("Inferred type containing Serializable")
+    assertError(result)("Inferred type containing Serializable: java.io.Serializable")
   }
+
   test("Serializable wart obeys SuppressWarnings") {
     val result = WartTestTraverser(JavaSerializable) {
       @SuppressWarnings(Array("org.wartremover.warts.JavaSerializable"))

--- a/core/src/test/scala/wartremover/warts/NothingTest.scala
+++ b/core/src/test/scala/wartremover/warts/NothingTest.scala
@@ -11,8 +11,9 @@ class NothingTest extends FunSuite with ResultAssertions {
       val x = ???
       x
     }
-    assertError(result)("Inferred type containing Nothing")
+    assertError(result)("Inferred type containing Nothing: Nothing")
   }
+
   test("Nothing wart obeys SuppressWarnings") {
     val result = WartTestTraverser(Nothing) {
       @SuppressWarnings(Array("org.wartremover.warts.Nothing"))

--- a/core/src/test/scala/wartremover/warts/ProductTest.scala
+++ b/core/src/test/scala/wartremover/warts/ProductTest.scala
@@ -10,8 +10,9 @@ class ProductTest extends FunSuite with ResultAssertions {
     val result = WartTestTraverser(Product) {
       List((1, 2, 3), (1, 2))
     }
-    assertError(result)("Inferred type containing Product")
+    assertError(result)("Inferred type containing Product: Product with Serializable")
   }
+
   test("Product wart obeys SuppressWarnings") {
     val result = WartTestTraverser(Product) {
       @SuppressWarnings(Array("org.wartremover.warts.Product"))

--- a/core/src/test/scala/wartremover/warts/SerializableTest.scala
+++ b/core/src/test/scala/wartremover/warts/SerializableTest.scala
@@ -10,8 +10,9 @@ class SerializableTest extends FunSuite with ResultAssertions {
     val result = WartTestTraverser(Serializable) {
       List((1, 2, 3), (1, 2))
     }
-    assertError(result)("Inferred type containing Serializable")
+    assertError(result)("Inferred type containing Serializable: Product with Serializable")
   }
+
   test("Serializable wart obeys SuppressWarnings") {
     val result = WartTestTraverser(Serializable) {
       @SuppressWarnings(Array("org.wartremover.warts.Serializable"))

--- a/core/src/test/scala/wartremover/warts/UnsafeTest.scala
+++ b/core/src/test/scala/wartremover/warts/UnsafeTest.scala
@@ -17,15 +17,18 @@ class UnsafeTest extends FunSuite {
       println(Right(42).right.get)
       println(null)
     }
+
     assertResult(
-      Set("[wartremover:Any] Inferred type containing Any",
+      Set("[wartremover:Any] Inferred type containing Any: Any",
            "[wartremover:EitherProjectionPartial] LeftProjection#get is disabled - use LeftProjection#toOption instead",
+           "[wartremover:Any] Inferred type containing Any: List[Any]",
            "[wartremover:EitherProjectionPartial] RightProjection#get is disabled - use RightProjection#toOption instead",
            "[wartremover:NonUnitStatements] Statements must return Unit",
            "[wartremover:Null] null is disabled",
            "[wartremover:OptionPartial] Option#get is disabled - use Option#fold instead",
            "[wartremover:StringPlusAny] Implicit conversion to string is disabled",
            "[wartremover:Var] var is disabled"), "result.errors")(result.errors.toSet)
+
     assertResult(List.empty, "result.warnings")(result.warnings)
   }
 }


### PR DESCRIPTION
e.g. Instead of `[wartremover:CustomAnyValWart] Inferred type containing AnyVal` display `[wartremover:CustomAnyValWart] Inferred type containing AnyVal: scala.concurrent.Future[AnyVal]` (easier to understand and fix)