### PR TITLE
updated documentation example, such that wartremover works.

### DIFF
--- a/docs/_posts/2017-02-11-install-setup.md
+++ b/docs/_posts/2017-02-11-install-setup.md
@@ -17,25 +17,26 @@ addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.3")
 Now, you can proceed to configure the linter in your `build.sbt`. By default, all errors and warnings are turned off. To turn on all checks that are currently considered stable, use:
 
 ```scala
-wartremoverErrors ++= Warts.unsafe
+Compile / wartremoverErrors ++= Warts.unsafe
 ```
 
 To turn on *all* available errors (some have false positives), use:
 
 ```scala
-wartremoverErrors ++= Warts.all
+Compile / wartremoverErrors ++= Warts.all
 ```
 
 Similarly, to just issue warnings instead of errors for all built-in warts, you can use:
 
 ```scala
-wartremoverWarnings ++= Warts.all    // or Warts.unsafe
+Compile / wartremoverWarnings ++= Warts.all    // or Warts.unsafe
 ```
 
 You can also use scopes, e.g. to turn on all warts only for compilation (and not for the tests nor the `sbt console`), use:
 
 ```scala
-wartremoverErrors in (Compile, compile) ++= Warts.all
+Compile / compile / wartremoverWarnings ++= Warts.unsafe,
+Test / wartremoverWarnings ++= Warts.all,
 ```
 
 To choose warts more selectively, use any of the following:


### PR DESCRIPTION
 basically wartremover must be prefixed by Compile otherwise it won't work.