### PR TITLE
Fix deprecated methods all pointing to `wartremoverErrors`

### DIFF
--- a/sbt-plugin/src/main/scala/wartremover/package.scala
+++ b/sbt-plugin/src/main/scala/wartremover/package.scala
@@ -6,11 +6,11 @@ package object wartremover {
   @deprecated(message = "will be removed. use wartremover.WartRemover.autoImport.wartremoverErrors instead", since = "2.4.7")
   val wartremoverErrors = autoImport.wartremoverErrors
   @deprecated(message = "will be removed. use wartremover.WartRemover.autoImport.wartremoverWarnings instead", since = "2.4.7")
-  val wartremoverWarnings = autoImport.wartremoverErrors
+  val wartremoverWarnings = autoImport.wartremoverWarnings
   @deprecated(message = "will be removed. use wartremover.WartRemover.autoImport.wartremoverExcluded instead", since = "2.4.7")
-  val wartremoverExcluded = autoImport.wartremoverErrors
+  val wartremoverExcluded = autoImport.wartremoverExcluded
   @deprecated(message = "will be removed. use wartremover.WartRemover.autoImport.wartremoverClasspaths instead", since = "2.4.7")
-  val wartremoverClasspaths = autoImport.wartremoverErrors
+  val wartremoverClasspaths = autoImport.wartremoverClasspaths
 
   @deprecated(message = "will be removed. use wartremover.WartRemover.projectSettings", since = "2.4.7")
   lazy val wartremoverSettings: Seq[sbt.Def.Setting[_]] =


### PR DESCRIPTION
This caused a compiler error for me:
```
[error] No implicit for Append.Values[Seq[wartremover.Wart], Seq[sbt.File]] found,
[error]   so Seq[sbt.File] cannot be appended to Seq[wartremover.Wart]
[error]     wartremover.wartremoverExcluded ++= RoutesKeys.routes.in(Compile).value,
```

But of course, this can lead to more subtle errors in other circumstances... :worried: 