### PR TITLE
Fix `unsafe` wart list being out of date

### DIFF
--- a/docs/_posts/2017-02-11-warts.md
+++ b/docs/_posts/2017-02-11-warts.md
@@ -380,8 +380,10 @@ Checks for the following warts:
 
 * Any
 * AsInstanceOf
+* DefaultArguments
 * EitherProjectionPartial
 * IsInstanceOf
+* TraversableOps
 * NonUnitStatements
 * Null
 * OptionPartial
@@ -390,9 +392,10 @@ Checks for the following warts:
 * Serializable
 * StringPlusAny
 * Throw
-* TraversableOps
 * TryPartial
 * Var
+
+This list is built from [Unsafe.scala](https://github.com/wartremover/wartremover/blob/master/core/src/main/scala/wartremover/warts/Unsafe.scala)
 
 ### Var
 


### PR DESCRIPTION
I noticed this doc page was outdated