### PR TITLE
- implement Contains Wart for List and Option

### DIFF
--- a/core/src/main/scala/wartremover/warts/Contains.scala
+++ b/core/src/main/scala/wartremover/warts/Contains.scala
@@ -1,0 +1,34 @@
+package org.wartremover
+package warts
+
+object Contains extends WartTraverser {
+  private[warts] def message: String = "Don't use List or Option `contains` method because is not typesafe"
+  override def apply(u: WartUniverse): u.Traverser = {
+    import u.universe._
+
+    val containsName = TermName("contains").encodedName
+
+    new u.Traverser {
+
+      override def traverse(tree: Tree): Unit = {
+
+        val listType = rootMirror.staticClass("scala.collection.immutable.List").asType.toTypeConstructor
+        val optionType = rootMirror.staticClass("scala.Option").asType.toTypeConstructor
+
+        tree match {
+          case t if hasWartAnnotation(u)(t) =>
+          // Ignore trees marked by SuppressWarnings
+          case Apply(TypeApply(Select(receiver, method), _), _) if
+            ((receiver.tpe.typeConstructor <:< listType) || (receiver.tpe.typeConstructor <:< optionType))
+              && (method == containsName)
+          =>
+            error(u)(tree.pos, message)
+          case _ =>
+            super.traverse(tree)
+        }
+
+      }
+
+    }
+  }
+}

--- a/core/src/test/scala/wartremover/warts/ContainsTest.scala
+++ b/core/src/test/scala/wartremover/warts/ContainsTest.scala
@@ -1,0 +1,45 @@
+package org.wartremover
+package test
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.wartremover.warts.Contains
+
+class ContainsTest extends AnyFunSuite with ResultAssertions {
+
+  val msg = "Don't use List or Option `contains` method because is not typesafe"
+
+  test("List.contains") {
+    val result = WartTestTraverser(Contains) {
+      List(1).contains(1)
+    }
+
+    assertError(result)(msg)
+  }
+
+  test("Option.contains") {
+    val result = WartTestTraverser(Contains) {
+      Option(1).contains("1")
+    }
+
+    assertError(result)(msg)
+  }
+
+  test("List.flatten.contains") {
+    def l = List(List(1, 2, 3), List(4, 5, 6, 7))
+
+    val result = WartTestTraverser(Contains) {
+      l.flatten.contains(1)
+    }
+
+    assertError(result)(msg)
+  }
+
+  test("Contains wart obeys SuppressWarnings") {
+    val result = WartTestTraverser(Contains) {
+      @SuppressWarnings(Array("org.wartremover.warts.Contains"))
+      val foo = List(1).contains(1)
+    }
+
+    assertEmpty(result)
+  }
+}

--- a/docs/_posts/2017-02-11-warts.md
+++ b/docs/_posts/2017-02-11-warts.md
@@ -47,6 +47,15 @@ val xs = List(1, true)
 x.asInstanceOf[String]
 ```
 
+### Contains
+`contains` in Lists and Options is type unsafe it is possible to implement List(1).contains("1"). Use type-safe implementation for example from cats `List.contains_`
+````scala
+// Won't compile: List.contains is disabled
+List(1).contains(1)
+// Won't compile: Option.contains is disabled
+Option(1).contains(1)
+````
+
 ### DefaultArguments
 
 Scala allows methods to have default arguments, which make it hard to use methods as functions.


### PR DESCRIPTION
Current situation: 

`List.contains` and `Option.contains` operations are not type-safe, which means it is possible to compile `List(1).contains("1")`

this wart disables contains in List's and Options

it was also suggested here - https://github.com/wartremover/wartremover/issues/48

