### PR TITLE
Use wildcards in quotes pattern matching

### DIFF
--- a/core/src/main/scala-3/org/wartremover/warts/PlatformDefault.scala
+++ b/core/src/main/scala-3/org/wartremover/warts/PlatformDefault.scala
@@ -25,7 +25,7 @@ object PlatformDefault extends WartTraverser {
             t.asExpr match {
               case '{ ($x: String).getBytes } =>
                 error(tree.pos, getByte)
-              case '{ ($x1: String).toLowerCase } | '{ ($x2: String).toUpperCase } =>
+              case '{ (${_}: String).toLowerCase } | '{ (${_}: String).toUpperCase } =>
                 error(tree.pos, upperLowerCase)
               case '{ new String(($x: Array[Byte])) } =>
                 error(tree.pos, newString)


### PR DESCRIPTION
Scala 3.2.x is more strict about matching quotes, now it throws compile-time errors when using named variables in alternative patterns. This PR fixes case failing in the latest 3.2.0-RC1 nightly builds https://scala3.westeurope.cloudapp.azure.com/blue/organizations/jenkins/buildCommunityProject/detail/buildCommunityProject/1413/pipeline