### PR TITLE
Add wart for `???`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -326,7 +326,7 @@ lazy val sbtPlug: Project = Project(
     val base = (Compile / sourceManaged).value
     val file = base / "wartremover" / "Wart.scala"
     val warts = wartClasses.value
-    val expectCount = 59
+    val expectCount = 60
     assert(
       warts.size == expectCount,
       s"${warts.size} != ${expectCount}. please update build.sbt when add or remove wart"

--- a/core/src/main/scala-2/org/wartremover/warts/TripleQuestionMark.scala
+++ b/core/src/main/scala-2/org/wartremover/warts/TripleQuestionMark.scala
@@ -1,0 +1,25 @@
+package org.wartremover
+package warts
+
+object TripleQuestionMark extends WartTraverser {
+  def apply(u: WartUniverse): u.Traverser = {
+    import u.universe._
+    val TripleQuestionMarkName = TermName("$qmark$qmark$qmark")
+    val predefSymbol = rootMirror.staticModule("scala.Predef")
+
+    new u.Traverser {
+      override def traverse(tree: Tree): Unit = {
+        tree match {
+          // Ignore trees marked by SuppressWarnings
+          case t if hasWartAnnotation(u)(t) =>
+          case Select(left, TripleQuestionMarkName) if left.symbol == predefSymbol =>
+            error(u)(tree.pos, "??? is disabled")
+          // TODO: This ignores a lot
+          case LabelDef(_, _, rhs) if isSynthetic(u)(tree) =>
+          case _ =>
+            super.traverse(tree)
+        }
+      }
+    }
+  }
+}

--- a/core/src/main/scala-3/org/wartremover/warts/TripleQuestionMark.scala
+++ b/core/src/main/scala-3/org/wartremover/warts/TripleQuestionMark.scala
@@ -2,6 +2,6 @@ package org.wartremover
 package warts
 
 object TripleQuestionMark
-  extends ExprMatch({ case '{ scala.Predef.??? } =>
-    "??? is disabled"
-  })
+    extends ExprMatch({ case '{ scala.Predef.??? } =>
+      "??? is disabled"
+    })

--- a/core/src/main/scala-3/org/wartremover/warts/TripleQuestionMark.scala
+++ b/core/src/main/scala-3/org/wartremover/warts/TripleQuestionMark.scala
@@ -1,0 +1,7 @@
+package org.wartremover
+package warts
+
+object TripleQuestionMark
+  extends ExprMatch({ case '{ scala.Predef.??? } =>
+    "??? is disabled"
+  })

--- a/core/src/main/scala/org/wartremover/warts/Unsafe.scala
+++ b/core/src/main/scala/org/wartremover/warts/Unsafe.scala
@@ -17,6 +17,7 @@ object Unsafe extends WartTraverser {
     Serializable,
     StringPlusAny,
     Throw,
+    TripleQuestionMark,
     TryPartial,
     Var
   )

--- a/core/src/test/scala/org/wartremover/test/TripleQuestionMarkTest.scala
+++ b/core/src/test/scala/org/wartremover/test/TripleQuestionMarkTest.scala
@@ -1,0 +1,29 @@
+package org.wartremover.test
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.wartremover.warts.TripleQuestionMark
+
+class TripleQuestionMarkTest extends AnyFunSuite with ResultAssertions {
+  test("??? is disabled") {
+    val result = WartTestTraverser(TripleQuestionMark) {
+      def foo(n: Int): Int = ???
+    }
+    assertError(result)("??? is disabled")
+  }
+
+  test("doesn't detect other `???` methods") {
+    val result = WartTestTraverser(TripleQuestionMark) {
+      case class A(`???`: Int)
+      println(A(1).`???`)
+    }
+    assertEmpty(result)
+  }
+
+  test("Throw wart obeys SuppressWarnings") {
+    val result = WartTestTraverser(TripleQuestionMark) {
+      @SuppressWarnings(Array("org.wartremover.warts.TripleQuestionMark"))
+      def foo(n: Int): Int = ???
+    }
+    assertEmpty(result)
+  }
+}

--- a/docs/_posts/2017-02-11-warts.md
+++ b/docs/_posts/2017-02-11-warts.md
@@ -342,7 +342,7 @@ case object Foo { override val toString = "Foo" }
 
 ### IterableOps
 
-`scala.collection.Iteable` has:
+`scala.collection.Iterable` has:
 
 * `head`,
 * `tail`,
@@ -368,6 +368,16 @@ all of which will throw if the collection is empty. The program should be refact
 
 to explicitly handle empty collections.
 
+
+### TripleQuestionMark
+
+`???` throws `NotImplementedError`. Encode exceptions/errors as return values instead using `Either`.
+
+```scala
+// Won't compile: ??? is disabled
+def foo: Int = ???
+```
+
 ### TryPartial
 
 `scala.util.Try` has a `get` method which will throw if the value is a
@@ -392,6 +402,7 @@ Checks for the following warts:
 * Serializable
 * StringPlusAny
 * Throw
+* TripleQuestionMark
 * TryPartial
 * Var
 


### PR DESCRIPTION
Adds a wart for `???`. `???` is unsafe, and it has a higher likelihood of accidentally being left in code due to many IDE generating stubs with `???`.