### PR TITLE
Do not execute `+publishLocal` when running scripted tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
             sbt -v "project core" "testPartial 3 ${{matrix.test_index}}"
             ;;
           "scripted")
-            sbt -v "+ publishLocal" "sbt-plugin/scripted wartremover/*${{matrix.test_index}}of3"
+            sbt -v "sbt-plugin/scripted wartremover/*${{matrix.test_index}}of3"
             ;;
           "inspector")
             sbt -v SetLatestStableScala3 inspector/test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target/
 wartremover-assembly.jar
+.bsp/
+.idea/


### PR DESCRIPTION
Hey! I might be wrong, but maybe the currently executable `+publishLocal` is redundant when running scripted tests of the sbt plugin?