### PR TITLE
SizeIs: support != operator

### DIFF
--- a/core/src/main/scala-2/org/wartremover/warts/SizeIs.scala
+++ b/core/src/main/scala-2/org/wartremover/warts/SizeIs.scala
@@ -11,6 +11,7 @@ object SizeIs extends WartTraverser {
         "<",
         "<=",
         "==",
+        "!=",
         ">",
         ">="
       ).map(NameTransformer.encode).map(TermName.apply(_))

--- a/core/src/main/scala-3/org/wartremover/warts/SizeIs.scala
+++ b/core/src/main/scala-3/org/wartremover/warts/SizeIs.scala
@@ -17,6 +17,8 @@ object SizeIs extends WartTraverser {
                 error(tree.pos, sizeMessage)
               case '{ ($x1: Iterable[t]).size == ($x2: Int) } =>
                 error(tree.pos, sizeMessage)
+              case '{ ($x1: Iterable[t]).size != ($x2: Int) } =>
+                error(tree.pos, sizeMessage)
               case '{ ($x1: Iterable[t]).size <= ($x2: Int) } =>
                 error(tree.pos, sizeMessage)
               case '{ ($x1: Iterable[t]).size > ($x2: Int) } =>
@@ -28,7 +30,7 @@ object SizeIs extends WartTraverser {
                 error(tree.pos, lengthMessage)
               case '{ ($x1: collection.Seq[t]).length == ($x2: Int) } =>
                 error(tree.pos, lengthMessage)
-              case '{ ($x1: collection.Seq[t]).length == ($x2: Int) } =>
+              case '{ ($x1: collection.Seq[t]).length != ($x2: Int) } =>
                 error(tree.pos, lengthMessage)
               case '{ ($x1: collection.Seq[t]).length <= ($x2: Int) } =>
                 error(tree.pos, lengthMessage)

--- a/core/src/test/scala/org/wartremover/test/SizeIsTest.scala
+++ b/core/src/test/scala/org/wartremover/test/SizeIsTest.scala
@@ -10,10 +10,11 @@ class SizeIsTest extends AnyFunSuite with ResultAssertions {
       List(3).size == 1
       Vector(3).size <= 1
       Iterable(3).size >= 1
+      Seq(3).size != 1
       Map.empty[Int, String].size > 1
       Set.empty[Boolean].size < 1
     }
-    assertErrors(result)("Maybe you can use `sizeIs` instead of `size`", 5)
+    assertErrors(result)("Maybe you can use `sizeIs` instead of `size`", 6)
   }
 
   test("suggest lengthIs") {


### PR DESCRIPTION
SizeCompareOps defines `!=`. It might be helpful for SizeIs to suggest it.
https://www.scala-lang.org/api/2.13.0/scala/collection/IterableOps$$SizeCompareOps.html