### PR TITLE
remove unnecessary `case`

### DIFF
--- a/core/src/main/scala-3/org/wartremover/warts/Discard.scala
+++ b/core/src/main/scala-3/org/wartremover/warts/Discard.scala
@@ -104,7 +104,7 @@ abstract class Discard(filter: Quotes ?=> ([a <: AnyKind] => Type[a] => Boolean)
                 case x: Ident if filterFunc(x.tpe) =>
                   x.name -> x.tpe
               }
-              .foreach { case (name, tpe) =>
+              .foreach { (name, tpe) =>
                 val accumulator = new TreeAccumulator[Set[String]] {
                   override def foldTree(x: Set[String], t: Tree)(owner: Symbol) = {
                     foldOverTree(

--- a/inspector/src/test/scala-3/org/wartremover/WartRemoverInspectorTest.scala
+++ b/inspector/src/test/scala-3/org/wartremover/WartRemoverInspectorTest.scala
@@ -128,7 +128,7 @@ class WartRemoverInspectorTest extends AnyFunSuite {
             inspector.run(param)
           }
       }
-      jar.getName -> result.warnings.map(_.wart.replace(packagePrefix, "")).groupBy(identity).map { case (k, v) =>
+      jar.getName -> result.warnings.map(_.wart.replace(packagePrefix, "")).groupBy(identity).map { (k, v) =>
         k -> v.size
       }
     }.toMap


### PR DESCRIPTION
- https://docs.scala-lang.org/scala3/reference/other-new-features/parameter-untupling.html
- https://github.com/xuwei-k/scalafix-rules/blob/f0cfd168a40565235236e6199c72070731ae601a/rules/src/main/scala/fix/RemoveParameterUntuplingCase.scala