### PR TITLE
Fix excluded path matching under Bloop/Metals

### DIFF
--- a/core/src/main/scala-2/org/wartremover/Plugin.scala
+++ b/core/src/main/scala-2/org/wartremover/Plugin.scala
@@ -81,8 +81,7 @@ class Plugin(val global: Global) extends tools.nsc.plugins.Plugin {
 
     traversers = ts("traverser")
     onlyWarnTraversers = ts("only-warn-traverser")
-    excludedFiles =
-      filterOptions("excluded", options) flatMap (_ split ":") map (_.trim) map (new java.io.File(_).getAbsolutePath)
+    excludedFiles = filterOptions("excluded", options) flatMap (_ split ":") map (_.trim)
 
     logLevel match {
       case LogLevel.Debug | LogLevel.Info =>
@@ -125,7 +124,23 @@ class Plugin(val global: Global) extends tools.nsc.plugins.Plugin {
       }
 
       override def apply(unit: CompilationUnit) = {
-        val isExcluded = excludedFiles exists unit.source.file.absolute.path.startsWith
+        val isExcluded = {
+          val sourcePath = unit.source.file.absolute.path
+          excludedFiles.exists { path =>
+            val f = new java.io.File(path)
+            if (f.isAbsolute) {
+              sourcePath.startsWith(path)
+            } else {
+              // Resolve against user.dir (works under sbt where user.dir == project root)
+              sourcePath.startsWith(f.getAbsolutePath) || {
+                // Suffix match for tools like Bloop/Metals where user.dir != project root
+                val sep = java.io.File.separator
+                val suffix = sep + path.replace("/", sep).replace("\\", sep)
+                sourcePath.endsWith(suffix) || sourcePath.contains(suffix + sep)
+              }
+            }
+          }
+        }
 
         if (isExcluded) {
           logLevel match {

--- a/core/src/main/scala-3/org/wartremover/Plugin.scala
+++ b/core/src/main/scala-3/org/wartremover/Plugin.scala
@@ -38,7 +38,7 @@ class Plugin extends StandardPlugin with CompilerPluginCompat {
     context: Option[Context]
   ): List[PluginPhase] = {
     val excluded = options.collect { case s"excluded:${path}" =>
-      new File(path).getAbsolutePath
+      path
     }
     val classPathEntries = options.collect {
       case s"cp:file:${c}" =>

--- a/core/src/main/scala-3/org/wartremover/WartremoverPhase.scala
+++ b/core/src/main/scala-3/org/wartremover/WartremoverPhase.scala
@@ -97,7 +97,23 @@ class WartremoverPhase(
         }
       case LogLevel.Disable =>
     }
-    val skip = excluded.exists(c.source.file.absolute.path.startsWith)
+    val skip = {
+      val sourcePath = c.source.file.absolute.path
+      excluded.exists { path =>
+        val f = new java.io.File(path)
+        if (f.isAbsolute) {
+          sourcePath.startsWith(path)
+        } else {
+          // Resolve against user.dir (works under sbt where user.dir == project root)
+          sourcePath.startsWith(f.getAbsolutePath) || {
+            // Suffix match for tools like Bloop/Metals where user.dir != project root
+            val sep = java.io.File.separator
+            val suffix = sep + path.replace("/", sep).replace("\\", sep)
+            sourcePath.endsWith(suffix) || sourcePath.contains(suffix + sep)
+          }
+        }
+      }
+    }
     logLevel match {
       case LogLevel.Info | LogLevel.Disable =>
       case LogLevel.Debug =>


### PR DESCRIPTION
## Problem

The sbt plugin relativizes `wartremoverExcluded` paths (workaround for sbt/sbt#6027). The compiler plugin then resolves these relative paths via `new File(path).getAbsolutePath`, which uses `user.dir`. Under sbt, `user.dir` is the project root so this works. Under Bloop/Metals, `user.dir` is the Bloop server's working directory, so the resolved absolute path doesn't match any source file path. Exclusions are silently ignored and generated code gets linted.

## Fix

When a relative excluded path doesn't match via absolute resolution, fall back to suffix matching against the source file path. This preserves existing sbt behavior (the absolute resolution still succeeds first) while correctly handling Bloop and any other tool where `user.dir` differs from the project root.

Changes in both Scala 2 (`Plugin.scala`) and Scala 3 (`Plugin.scala`, `WartremoverPhase.scala`).

## Testing

Verified in a large multi-module sbt project (200+ modules) using Metals with Bloop. Modules with protobuf-generated managed sources in `wartremoverExcluded` now compile cleanly without false wartremover errors under Bloop.
